### PR TITLE
CODEOWNERS on one line

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, these accounts
 # will be requested for review when someone opens a pull request.
-*   @speller26 @floralph
+*   @speller26 @floralph @avawang1


### PR DESCRIPTION
Separate line version was wrong:
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
