### PR TITLE
Setting whitelist_externals setting to "coverage" to stop a warning.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = linters,docs,unit-tests
 
 [testenv:unit-tests]
+whitelist_externals = coverage
 # {posargs} contains additional arguments specified when invoking tox. e.g. tox -- -s -k test_foo.py
 commands =
     coverage run -m pytest {posargs}


### PR DESCRIPTION
Setting whitelist_externals setting to "coverage" to stop a warning.
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
