### PR TITLE
Remove braket/schema_common from braket-ir from coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ source =
     braket
 omit =
     **/braket/ir/*
+    **/braket/schema_common/*
 
 [paths]
 source =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove braket/schema_common from braket-ir from coverage. Without this fix, coverage doesn't pass in tox.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
