### PR TITLE
Migrate to new task result object

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ source =
 omit =
     **/braket/ir/*
     **/braket/schema_common/*
+    **/braket/task_result/*
 
 [paths]
 source =

--- a/src/braket/simulator/braket_simulator.py
+++ b/src/braket/simulator/braket_simulator.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Union
 
 from braket.ir.annealing import Problem
 from braket.ir.jaqcd import Program
+from braket.task_result import AnnealingTaskResult, GateModelTaskResult
 
 
 class IrType(str, Enum):
@@ -52,8 +53,11 @@ class BraketSimulator(ABC):
     """
 
     @abstractmethod
-    def run(self, ir: Union[Program, Problem], *args, **kwargs) -> Dict[str, Any]:
-        """ Run the task specified by the given IR.
+    def run(
+        self, ir: Union[Program, Problem], *args, **kwargs
+    ) -> Union[GateModelTaskResult, AnnealingTaskResult]:
+        """
+        Run the task specified by the given IR.
 
         Extra arguments will contain any additional information necessary to run the task,
         such as number of qubits.
@@ -62,10 +66,8 @@ class BraketSimulator(ABC):
             ir (Union[Program, Problem]): The IR representation of the program
 
         Returns:
-            Dict[str, Any]: A dict containing the results of the simulation.
-            In order to work with braket-python-sdk, the format of the JSON dict should
-            match that needed by GateModelQuantumTaskResult or AnnealingQuantumTaskResult
-            from the SDK, depending on the type of task.
+            Union[GateModelTaskResult, AnnealingTaskResult]: An object representing
+            the results of the simulation.
         """
 
     @property


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Migrate to new task result object
* `run` now returns a `GateModelTaskResult` object

[build_files.tar.gz](https://github.com/aws/amazon-braket-default-simulator-python/files/4967390/build_files.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
