### PR TITLE
fix: visit reset qubit node

### DIFF
--- a/src/braket/default_simulator/openqasm/native_interpreter.py
+++ b/src/braket/default_simulator/openqasm/native_interpreter.py
@@ -96,7 +96,7 @@ class NativeInterpreter(Interpreter):
     def _(self, node: QuantumReset) -> None:
         self.logger.debug(f"Quantum reset: {node}")
         self.simulation.evolve(self.context.pop_instructions())
-        targets = self.context.get_qubits(node.qubits)
+        targets = self.context.get_qubits(self.visit(node.qubits))
         outcome = self.simulation.measure(targets)
         for qubit, result in zip(targets, outcome):
             if result:

--- a/test/unit_tests/braket/default_simulator/openqasm/test_native_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_native_interpreter.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from braket.default_simulator import StateVectorSimulation
+from braket.default_simulator.openqasm.native_interpreter import NativeInterpreter
+
+
+@pytest.mark.parametrize(
+    "reset_instructions",
+    (
+        "for int q in [0:2 - 1] {\n    reset __qubits__[q];\n}",
+        "array[int[32], 2] __arr_0__ = {0, 1};\nfor int q in __arr_0__ {\n    reset __qubits__[q];\n}",
+        "reset __qubits__[0];\nreset __qubits__[1];",
+    ),
+)
+def test_reset(reset_instructions):
+    qasm = f"""
+    OPENQASM 3.0;
+    qubit[2] __qubits__;
+    x __qubits__[0];
+    x __qubits__[1];
+    {reset_instructions}
+    bit[2] __bit_0__ = "00";
+    __bit_0__[0] = measure __qubits__[0];
+    __bit_0__[1] = measure __qubits__[1];
+    """
+
+    result = NativeInterpreter(StateVectorSimulation(0, 0, 1)).simulate(qasm)
+    assert result["__bit_0__"] == ["00"]

--- a/test/unit_tests/braket/default_simulator/openqasm/test_native_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_native_interpreter.py
@@ -23,6 +23,7 @@ from braket.default_simulator.openqasm.native_interpreter import NativeInterpret
         "for int q in [0:2 - 1] {\n    reset __qubits__[q];\n}",
         "array[int[32], 2] __arr_0__ = {0, 1};\nfor int q in __arr_0__ {\n    reset __qubits__[q];\n}",
         "reset __qubits__[0];\nreset __qubits__[1];",
+        "reset __qubits__;",
     ),
 )
 def test_reset(reset_instructions):


### PR DESCRIPTION
*Description of changes:*
visit qubit node of reset

Enabling using identifier as qubit index for reset.
```
OPENQASM 3.0;
qubit[2] __qubits__;
array[int[32], 2] __arr_0__ = {0, 1};
for int q in __arr_0__ {
    reset __qubits__[q];
}
```

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
