### PR TITLE
infra: remove pydantic constraints

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,5 @@
 """Sphinx configuration."""
+
 import datetime
 
 import pkg_resources

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ testpaths = test/unit_tests
 line_length = 100
 multi_line_output = 3
 include_trailing_comma = true
+profile=black
 
 [flake8]
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "numpy",
         "opt_einsum",
-        "pydantic>=1.9,<2.0",
+        "pydantic",
         "scipy",
         "sympy",
         # pinned for compatibility with strawberry fields


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This relaxes the constraints for what Pydantic version is used. This imports the schemas package which already dictates that for Braket packages. If this relationship is decoupled, then would make sense to add back.

*Testing done:*
Ran unit tests and linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
