### PR TITLE
fix: support measurements on qubits without gates

### DIFF
--- a/src/braket/default_simulator/simulator.py
+++ b/src/braket/default_simulator/simulator.py
@@ -275,7 +275,7 @@ class BaseLocalSimulator(OpenQASMSimulator):
     @staticmethod
     def _validate_operation_qubits(operations: list[Operation]) -> None:
         qubits_referenced = {target for operation in operations for target in operation.targets}
-        if max(qubits_referenced) >= len(qubits_referenced):
+        if qubits_referenced and max(qubits_referenced) >= len(qubits_referenced):
             raise ValueError(
                 "Non-contiguous qubit indices supplied; "
                 "qubit indices in a circuit must be contiguous."
@@ -407,7 +407,37 @@ class BaseLocalSimulator(OpenQASMSimulator):
         ]
         #  Gets the subset of measurements from the full measurements
         if measured_qubits is not None and measured_qubits != []:
-            measurements = np.array(measurements)[:, measured_qubits].tolist()
+            if all(qubit in range(simulation.qubit_count) for qubit in measured_qubits):
+                measurements = np.array(measurements)[:, measured_qubits].tolist()
+            elif any(qubit in range(simulation.qubit_count) for qubit in measured_qubits):
+                measured_qubits_in_circuit = [
+                    qubit for qubit in measured_qubits if qubit in range(simulation.qubit_count)
+                ]
+                measured_qubits_not_in_circuit = [
+                    qubit for qubit in measured_qubits if qubit not in range(simulation.qubit_count)
+                ]
+
+                # get the list of measurements of qubits with gates on the circuit
+                measurements_in_circuit = np.array(measurements)[
+                    :, measured_qubits_in_circuit
+                ].tolist()
+                # set any measurements of qubits without gates to 0
+                measurements = np.zeros(
+                    (simulation.shots, len(measured_qubits_not_in_circuit)), dtype=int
+                ).tolist()
+
+                # Add measurements of qubits with gates on the circuit
+                for idx in measured_qubits_in_circuit:
+                    measurements[idx] = measurements_in_circuit[idx] + measurements[idx]
+
+                # Add measurements of 0s for qubits with no gates on the circuit
+                for idx, sublist in enumerate(measurements):
+                    if idx not in measured_qubits_in_circuit:
+                        measurements[idx] = measurements_in_circuit[idx] + measurements[idx]
+            else:
+                measurements = np.zeros(
+                    (simulation.shots, len(measured_qubits)), dtype=int
+                ).tolist()
         return measurements
 
     def run_openqasm(

--- a/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
@@ -795,3 +795,42 @@ def test_measure_targets():
     assert 400 < np.sum(measurements, axis=0)[0] < 600
     assert len(measurements[0]) == 1
     assert result.measuredQubits == [0]
+
+
+def test_measure_no_gates():
+    qasm = """
+    bit[4] b;
+    qubit[4] q;
+    b[0] = measure q[0];
+    b[1] = measure q[1];
+    b[2] = measure q[2];
+    b[3] = measure q[3];
+    """
+    simulator = DensityMatrixSimulator()
+    result = simulator.run(OpenQASMProgram(source=qasm), shots=1000)
+    measurements = np.array(result.measurements, dtype=int)
+    assert np.sum(measurements, axis=0)[0] == 0
+    assert len(measurements[0]) == 4
+    assert result.measuredQubits == [0, 1, 2, 3]
+
+
+def test_measure_with_qubits_not_used():
+    qasm = """
+    bit[4] b;
+    qubit[4] q;
+    h q[0];
+    cnot q[0], q[1];
+    b[0] = measure q[0];
+    b[1] = measure q[1];
+    b[2] = measure q[2];
+    b[3] = measure q[3];
+    """
+    simulator = DensityMatrixSimulator()
+    result = simulator.run(OpenQASMProgram(source=qasm), shots=1000)
+    measurements = np.array(result.measurements, dtype=int)
+    assert 400 < np.sum(measurements, axis=0)[0] < 600
+    assert 400 < np.sum(measurements, axis=0)[1] < 600
+    assert np.sum(measurements, axis=0)[2] == 0
+    assert np.sum(measurements, axis=0)[3] == 0
+    assert len(measurements[0]) == 4
+    assert result.measuredQubits == [0, 1, 2, 3]

--- a/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
@@ -1285,3 +1285,42 @@ def test_measure_targets():
     assert 400 < np.sum(measurements, axis=0)[0] < 600
     assert len(measurements[0]) == 1
     assert result.measuredQubits == [0]
+
+
+def test_measure_no_gates():
+    qasm = """
+    bit[4] b;
+    qubit[4] q;
+    b[0] = measure q[0];
+    b[1] = measure q[1];
+    b[2] = measure q[2];
+    b[3] = measure q[3];
+    """
+    simulator = StateVectorSimulator()
+    result = simulator.run(OpenQASMProgram(source=qasm), shots=1000)
+    measurements = np.array(result.measurements, dtype=int)
+    assert np.sum(measurements, axis=0)[2] == 0
+    assert len(measurements[0]) == 4
+    assert result.measuredQubits == [0, 1, 2, 3]
+
+
+def test_measure_with_qubits_not_used():
+    qasm = """
+    bit[4] b;
+    qubit[4] q;
+    h q[0];
+    cnot q[0], q[1];
+    b[0] = measure q[0];
+    b[1] = measure q[1];
+    b[2] = measure q[2];
+    b[3] = measure q[3];
+    """
+    simulator = StateVectorSimulator()
+    result = simulator.run(OpenQASMProgram(source=qasm), shots=1000)
+    measurements = np.array(result.measurements, dtype=int)
+    assert 400 < np.sum(measurements, axis=0)[0] < 600
+    assert 400 < np.sum(measurements, axis=0)[1] < 600
+    assert np.sum(measurements, axis=0)[2] == 0
+    assert np.sum(measurements, axis=0)[3] == 0
+    assert len(measurements[0]) == 4
+    assert result.measuredQubits == [0, 1, 2, 3]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the local simulators do not support measuring qubits that are not used (do not a gate) on the circuit. 

Example:

`Circuit().measure(0)`

`Circuit().h(0).cnot(0,1).measure([0, 1, 2])`

To support this any qubits that are measured but not used, should return 0

Example:
```
Circuit().measure(0)

[[0]
 [0]
 [0]
 [0]
 [0]
 [0]
 [0]
 [0]
 [0]
 [0]]

```
```
Circuit().h(0).cnot(0,1).measure([0, 1, 2])

[[1 1 0]
 [1 1 0]
 [0 0 0]
 [1 1 0]
 [1 1 0]
 [1 1 0]
 [0 0 0]
 [0 0 0]
 [1 1 0]
 [0 0 0]]
```

*Testing done:*
`tox` 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
