### PR TITLE
Support contiguous qubits for OpenQASM IR

### DIFF
--- a/src/braket/default_simulator/density_matrix_simulator.py
+++ b/src/braket/default_simulator/density_matrix_simulator.py
@@ -178,7 +178,7 @@ class DensityMatrixSimulator(BaseLocalSimulator):
                         ],
                         "supportPhysicalQubits": False,
                         "supportsPartialVerbatimBox": False,
-                        "requiresContiguousQubitIndices": True,
+                        "requiresContiguousQubitIndices": False,
                         "requiresAllQubitsMeasurement": False,
                         "supportsUnassignedMeasurements": True,
                         "disabledQubitRewiringSupported": False,

--- a/src/braket/default_simulator/state_vector_simulator.py
+++ b/src/braket/default_simulator/state_vector_simulator.py
@@ -238,7 +238,7 @@ class StateVectorSimulator(BaseLocalSimulator):
                         ],
                         "supportPhysicalQubits": False,
                         "supportsPartialVerbatimBox": False,
-                        "requiresContiguousQubitIndices": True,
+                        "requiresContiguousQubitIndices": False,
                         "requiresAllQubitsMeasurement": False,
                         "supportsUnassignedMeasurements": True,
                         "disabledQubitRewiringSupported": False,

--- a/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
@@ -1322,7 +1322,7 @@ def test_non_contiguous_qubits_with_observable():
     assert result.measuredQubits == [14, 15]
 
 
-def test_non_contiguous_qubits_with_observable_shots0():
+def test_non_contiguous_qubits_with_shots0():
     qasm = """
     OPENQASM 3.0;
     qubit[16] q;


### PR DESCRIPTION
*Description of changes:*
- Qubits are mapped to contiguous qubits before simulation
- Adapt the indices of measuredQubit in the returned simulation result

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
