### PR TITLE
fix: Fix a bug in the AHS local simulator when using local detuning with certain pattern with empty sites 

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -245,11 +245,10 @@ def _get_sparse_ops(
     local_detuning_ops = []
     for shifting_field in program.hamiltonian.shiftingFields:
         temp = 0
-        filled_site = 0 # Index of the filled site
+        filled_site = 0  # Index of the filled site
         for filling, strength in zip(
-                program.setup.ahs_register.filling, 
-                shifting_field.magnitude.pattern
-            ):
+            program.setup.ahs_register.filling, shifting_field.magnitude.pattern
+        ):
             # If the site is not filled, we move on to the next filled site
             if filling == 0:
                 continue

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -245,19 +245,19 @@ def _get_sparse_ops(
     local_detuning_ops = []
     for shifting_field in program.hamiltonian.shiftingFields:
         temp = 0
-        for site, (filling, strength) in enumerate(
-                zip(
-                    program.setup.ahs_register.filling, 
-                    shifting_field.magnitude.pattern
-                )
+        filled_site = 0 # Index of the filled site
+        for filling, strength in zip(
+                program.setup.ahs_register.filling, 
+                shifting_field.magnitude.pattern
             ):
             # If the site is not filled, we move on to the next filled site
             if filling == 0:
                 continue
             opt = _get_sparse_from_dict(
-                _get_detuning_dict((site,), configurations), len(configurations)
+                _get_detuning_dict((filled_site,), configurations), len(configurations)
             )
             temp += float(strength) * scipy.sparse.csr_matrix(opt, dtype=float)
+            filled_site += 1
 
         local_detuning_ops.append(temp)
 

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -245,12 +245,19 @@ def _get_sparse_ops(
     local_detuning_ops = []
     for shifting_field in program.hamiltonian.shiftingFields:
         temp = 0
-        for site in range(len(shifting_field.magnitude.pattern)):
-            strength = shifting_field.magnitude.pattern[site]
+        for site, (filling, strength) in enumerate(
+                zip(
+                    program.setup.ahs_register.filling, 
+                    shifting_field.magnitude.pattern
+                )
+            ):
+            # If the site is not filled, we move on to the next filled site
+            if filling == 0:
+                continue
             opt = _get_sparse_from_dict(
                 _get_detuning_dict((site,), configurations), len(configurations)
             )
-            temp += float(strength) * scipy.sparse.csr_matrix(opt, dtype=float)
+            temp += float(strength) * scipy.sparse.csr_matrix(opt, dtype=float)        
 
         local_detuning_ops.append(temp)
 

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -257,7 +257,7 @@ def _get_sparse_ops(
             opt = _get_sparse_from_dict(
                 _get_detuning_dict((site,), configurations), len(configurations)
             )
-            temp += float(strength) * scipy.sparse.csr_matrix(opt, dtype=float)        
+            temp += float(strength) * scipy.sparse.csr_matrix(opt, dtype=float)
 
         local_detuning_ops.append(temp)
 

--- a/src/braket/default_simulator/_version.py
+++ b/src/braket/default_simulator/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "1.18.2"
+__version__ = "1.18.3.dev0"

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import numpy as np
 import pytest
 from braket.ir.ahs.program_v1 import Program
@@ -161,6 +174,7 @@ def test_failed_scipy_run():
             "the allowed number of substeps by increasing "
             "the parameter `nsteps`."
         )
+
 
 # Test solver with non-constant amplitude and detuning
 

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
@@ -162,6 +162,62 @@ def test_failed_scipy_run():
             "the parameter `nsteps`."
         )
 
+# Test solver with non-constant amplitude and detuning
+
+# We use a single atom and set amplitude and detuning equal
+# to each other, so that the evolution can be solved exactly
+
+theta = np.pi / 2  # could be arbitrary value
+
+amplitude_2 = {
+    "pattern": "uniform",
+    "time_series": {"times": [0, tmax / 2, tmax], "values": [0.0, theta / tmax, 0.0]},
+}
+
+detuning_2 = {
+    "pattern": "uniform",
+    "time_series": {"times": [0, tmax / 2, tmax], "values": [0.0, theta / tmax, 0.0]},
+}
+
+phase_2 = {"pattern": "uniform", "time_series": {"times": [0, tmax], "values": [0, 0]}}
+
+driving_field_2 = {"amplitude": amplitude_2, "phase": phase_2, "detuning": detuning_2}
+
+setup_2 = {"ahs_register": {"sites": [[0, 0]], "filling": [1]}}
+hamiltonian_2 = {"drivingFields": [driving_field_2], "shiftingFields": []}
+
+program_2 = convert_unit(
+    Program(
+        setup=setup_2,
+        hamiltonian=hamiltonian_2,
+    )
+)
+
+theory_value_1 = (np.sin(1 / 2 * theta / np.sqrt(2)) / np.sqrt(2)) ** 2
+theory_value_0 = 1 - theory_value_1
+
+configurations_2 = ["g", "r"]
+true_final_prob_2 = [theory_value_0, theory_value_1]
+
+
+@pytest.mark.parametrize(
+    "solver",
+    [
+        scipy_integrate_ode_run,
+        rk_run,
+    ],
+)
+def test_solvers_non_constant_program(solver):
+    states = solver(
+        program_2,
+        configurations_2,
+        simulation_times,
+        rydberg_interaction_coef,
+    )
+    final_prob = [np.abs(i) ** 2 for i in states[-1]]
+
+    assert np.allclose(final_prob, true_final_prob_2, atol=1e-2)
+
 # Test a program with the following properties
 # 1. It has vacant site and a local detuning field
 # 2. The vacant site is added to the register before another filled site

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
@@ -232,15 +232,16 @@ def test_solvers_non_constant_program(solver):
 
     assert np.allclose(final_prob, true_final_prob_2, atol=1e-2)
 
+
 # Test a program with the following properties
 # 1. It has vacant site and a local detuning field
 # 2. The vacant site is added to the register before another filled site
-        
+
 # Define a global pi-pulse
 driving_field_pi_pulse = {
     "amplitude": {
         "pattern": "uniform",
-        "time_series": {"times": [0, tmax], "values": [np.pi/tmax, np.pi/tmax]},
+        "time_series": {"times": [0, tmax], "values": [np.pi / tmax, np.pi / tmax]},
     },
     "phase": {
         "pattern": "uniform",
@@ -254,7 +255,7 @@ driving_field_pi_pulse = {
 
 # Define the waveform for shifting field with large detuning values
 shifting_field_time_series = {
-    "times": [0, tmax], 
+    "times": [0, tmax],
     "values": [1e10, 1e10],
 }
 
@@ -264,51 +265,49 @@ ahs_register_1 = {"sites": [[0, 0], [10e-4, 0], [20e-4, 0]], "filling": [1, 1, 0
 pattern_1 = [0, 1, 1]
 
 # Case 2: the first site is filled, and the second site is empty
-# Note that the registers in case 1 and 2 are physically the same 
+# Note that the registers in case 1 and 2 are physically the same
 # but with different labelings
 ahs_register_2 = {"sites": [[20e-4, 0], [0, 0], [10e-4, 0]], "filling": [0, 1, 1]}
 pattern_2 = [1, 0, 1]
 
+
 # Define the programs for the two cases
 def get_program_with_vacant_site_pi_pulse(
-    ahs_register, 
+    ahs_register,
     pattern,
-    shifting_field_time_series = shifting_field_time_series,
-    driving_field_pi_pulse = driving_field_pi_pulse
+    shifting_field_time_series=shifting_field_time_series,
+    driving_field_pi_pulse=driving_field_pi_pulse,
 ):
-    shifting_field = {
-        "magnitude": {
-            "pattern": pattern,
-            "time_series": shifting_field_time_series
-        }
-    }
+    shifting_field = {"magnitude": {"pattern": pattern, "time_series": shifting_field_time_series}}
     return convert_unit(
         Program(
             setup={"ahs_register": ahs_register},
             hamiltonian={
-                "drivingFields": [driving_field_pi_pulse], 
-                "shiftingFields": [shifting_field]
+                "drivingFields": [driving_field_pi_pulse],
+                "shiftingFields": [shifting_field],
             },
         )
     )
 
-program_1 = get_program_with_vacant_site_pi_pulse(ahs_register_1, pattern_1)
-program_2 = get_program_with_vacant_site_pi_pulse(ahs_register_2, pattern_2)
+
+program_with_vacant_site_1 = get_program_with_vacant_site_pi_pulse(ahs_register_1, pattern_1)
+program_with_vacant_site_2 = get_program_with_vacant_site_pi_pulse(ahs_register_2, pattern_2)
 
 # Test the result. Upon inspection, we conclude that the state should be 'rg'
 # for both cases.
 
+
 @pytest.mark.parametrize(
     "solver, program",
     [
-        [scipy_integrate_ode_run, program_1],
-        [scipy_integrate_ode_run, program_2],
-        [rk_run, program_1],
-        [rk_run, program_2]
+        [scipy_integrate_ode_run, program_with_vacant_site_1],
+        [scipy_integrate_ode_run, program_with_vacant_site_2],
+        [rk_run, program_with_vacant_site_1],
+        [rk_run, program_with_vacant_site_2],
     ],
 )
 def test_program_with_vacant_site_pi_pulse(solver, program):
-    states = solver(program, ['gg', 'gr', 'rg', 'rr'], simulation_times, rydberg_interaction_coef)
+    states = solver(program, ["gg", "gr", "rg", "rr"], simulation_times, rydberg_interaction_coef)
     final_prob = [np.abs(i) ** 2 for i in states[-1]]
     true_final_prob = [0, 0, 1, 0]
     assert np.allclose(final_prob, true_final_prob, atol=1e-2)


### PR DESCRIPTION
*Issue #, if available:*
There is a bug in the AHS local simulator when it is used to simulate AHS program with local detuning with patterns where an empty site is specified before another filled site. This bug originates from [this line](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/420aeaf5e2d8366cea7ac7a3d4cf0214a8fc3aa3/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py#L76) and  [this line](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/420aeaf5e2d8366cea7ac7a3d4cf0214a8fc3aa3/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py#L260) where the former only indexes the filled sites but the latter loop through all the empty and filled sites. 

Hence, there will be a bug if and only if a program consists of a) a local detuning field and b) an empty site that is added to the register before another filled site. In other word, for a given register with empty and filled sites, if all the filled sites are added to the register before the empty sites, there will be no bug; the bug only manifests if an empty site is added before another filled site. 

To see the bug more explicitly, one could run the following example [the explanation is included inline]
```
import numpy as np
from braket.timings.time_series import TimeSeries
from braket.ahs.driving_field import DrivingField

# Step 1: Define a global pi-pulse
Omega_max = 2.5e6  # rad / seconds
t_max = np.pi/Omega_max
Omega = TimeSeries().put(0.0, Omega_max).put(t_max, Omega_max) # pi pulse

drive = DrivingField(
    amplitude=Omega,
    phase=TimeSeries.constant_like(Omega, 0),
    detuning=TimeSeries.constant_like(Omega, 0)
)

# Step 2: Define the waveform for the LD
from braket.ahs.field import Field
from braket.ahs.pattern import Pattern
from braket.ahs.shifting_field import ShiftingField

Delta_local = TimeSeries().put(0.0, -Omega_max*20).put(t_max, -Omega_max*20)


# Step 3: Define an atom arrangement with two different labelings
#         where one of the site is filled  without LD, and the other
#         site is empty and with strong LD
from braket.ahs.atom_arrangement import SiteType
from braket.ahs.atom_arrangement import AtomArrangement
from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation


# Case 1: the first site is filled, and the second site is empty
register1 = AtomArrangement().add((0, 0), site_type=SiteType.FILLED).add((10e-6, 0), site_type=SiteType.VACANT)
pattern1 = [0, 1]
shift1 = ShiftingField(magnitude=Field(time_series=Delta_local, pattern=Pattern(pattern1)))
program1 = AnalogHamiltonianSimulation(register1, drive + shift1)

# Case 2: the first site is filled, and the second site is empty
#         Notice register2 is the same as register1 but with different labeling,
#         and we have switch the labeling in the pattern accordingly

register2 = AtomArrangement().add((10e-6, 0), site_type=SiteType.VACANT).add((0, 0), site_type=SiteType.FILLED)
pattern2 = [1, 0]
shift2 = ShiftingField(magnitude=Field(time_series=Delta_local, pattern=Pattern(pattern2)))
program2 = AnalogHamiltonianSimulation(register2, drive + shift2)


# Step 4: Run the simulation with local sim
from braket.devices import LocalSimulator
device = LocalSimulator("braket_ahs")

result1 = device.run(program1, shots=1000, steps=100).result()
result2 = device.run(program2, shots=1000, steps=100).result()

# Step 5: Check the result. Here we expect, for both cases that
#         the post-sequence should be (0, 0) because the filled
#         site is in the Rydberg state.
#         However, we see that this is not the case for register2,
#         hence, there is a bug in the local sim

pos_seq1 = [tuple(meas.post_sequence) for meas in result1.measurements]
pos_seq2 = [tuple(meas.post_sequence) for meas in result2.measurements]

print([
    pos_seq1.count((0,0)), 
    pos_seq2.count((0,0)),
    pos_seq2.count((0,1))
])

# output: [1000, 0, 1000], but it should be [1000, 1000, 0]
```

*Description of changes:*
We change the for loop in getting the operator for the local detuning field (shifting field). 


*Testing done:*
One unit test, which is slightly more involved than the previous example, is added.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
