### PR TITLE
fix: make shifting fields backwards compatible with change to localDe…

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/validators/hamiltonian.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/validators/hamiltonian.py
@@ -27,7 +27,7 @@ class HamiltonianValidator(Hamiltonian):
 
     @root_validator(pre=True, skip_on_failure=True)
     def max_one_shifting_field(cls, values):
-        shifting_fields = values["shiftingFields"]
+        shifting_fields = values["shiftingFields"] if "shiftingFields" in values.keys() else values["localDetuning"]
         if len(shifting_fields) > 1:
             raise ValueError(
                 f"At most one shifting field should be specified; {len(shifting_fields)} are given."
@@ -44,7 +44,7 @@ class HamiltonianValidator(Hamiltonian):
                 end_times[f"{name} of driving field {index}"] = field[name]["time_series"]["times"][
                     -1
                 ]
-        for index, field in enumerate(values["shiftingFields"]):
+        for index, field in enumerate(values["shiftingFields"] if "shiftingFields" in values.keys() else values["localDetuning"]):
             for name in s_field_names:
                 end_times[f"{name} of shifting field {index}"] = field[name]["time_series"][
                     "times"

--- a/src/braket/analog_hamiltonian_simulator/rydberg/validators/program.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/validators/program.py
@@ -26,7 +26,7 @@ class ProgramValidator(Program):
     @root_validator(pre=True, skip_on_failure=True)
     def shifting_field_pattern_has_the_same_length_as_atom_array_sites(cls, values):
         num_sites = len(values["setup"]["ahs_register"]["sites"])
-        for idx, shifting_field in enumerate(values["hamiltonian"]["shiftingFields"]):
+        for idx, shifting_field in enumerate(values["hamiltonian"]["shiftingFields"] if "shiftingFields" in values["hamiltonian"].keys() else values["hamiltonian"]["localDetuning"]):
             pattern_size = len(shifting_field["magnitude"]["pattern"])
             if num_sites != pattern_size:
                 raise ValueError(


### PR DESCRIPTION
…tuning

*Issue #, if available:*

*Description of changes:*
Allows backwards compatability with: 
https://github.com/amazon-braket/amazon-braket-schemas-python/pull/174

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
