### PR TITLE
fix: cast node.size to IntegerLiteral for qubit register size

### DIFF
--- a/src/braket/default_simulator/openqasm/_helpers/functions.py
+++ b/src/braket/default_simulator/openqasm/_helpers/functions.py
@@ -98,10 +98,16 @@ operator_maps = {
             [BooleanLiteral(xv.value ^ yv.value) for xv, yv in zip(x.values, y.values)]
         ),
         getattr(BinaryOperator, "<<"): lambda x, y: ArrayLiteral(
-            x.values[y.value :] + [BooleanLiteral(False) for _ in range(y.value)]
+            x.values[len(y.values) :] + [BooleanLiteral(False) for _ in range(len(y.values))]
+            if isinstance(y, ArrayLiteral)
+            else x.values[y.value :] + [BooleanLiteral(False) for _ in range(y.value)]
         ),
         getattr(BinaryOperator, ">>"): lambda x, y: ArrayLiteral(
-            [BooleanLiteral(False) for _ in range(y.value)] + x.values[: len(x.values) - y.value]
+            [BooleanLiteral(False) for _ in range(len(y.values))]
+            + x.values[: len(x.values) - len(y.values)]
+            if isinstance(y, ArrayLiteral)
+            else [BooleanLiteral(False) for _ in range(y.value)]
+            + x.values[: len(x.values) - y.value]
         ),
         getattr(UnaryOperator, "~"): lambda x: ArrayLiteral(
             [BooleanLiteral(not v.value) for v in x.values]

--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -247,8 +247,13 @@ class Interpreter:
 
     @visit.register
     def _(self, node: QubitDeclaration) -> None:
-        size = self.visit(node.size).value if node.size else 1
-        self.context.add_qubits(node.qubit.name, size)
+        size_arg = self.visit(node.size)
+        if isinstance(size_arg, ArrayLiteral) and size_arg:
+            size = "".join(str(cast_to(IntegerLiteral, qubit).value) for qubit in size_arg.values)
+            self.context.add_qubits(node.qubit.name, int(size, 2))
+        else:
+            size = size_arg.value if size_arg else 1
+            self.context.add_qubits(node.qubit.name, size)
 
     @visit.register
     def _(self, node: QuantumReset) -> None:

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -2207,3 +2207,77 @@ def test_measure_invalid_qubit():
 def test_measure_qubit_out_of_range(qasm, expected):
     with pytest.raises(IndexError, match=expected):
         Interpreter().build_circuit(qasm)
+
+
+@pytest.mark.parametrize(
+    "qasm, expected",
+    [
+        (
+            """
+                bit[2] b;
+                qubit["10"] r1;
+                b = measure r1;
+            """,
+            [0, 1],
+        ),
+        (
+            """
+                bit[3] b;
+                qubit["11"] r1;
+                b = measure r1;
+            """,
+            [0, 1, 2],
+        ),
+        (
+            """
+                bit[1] b;
+                qubit[!"1"] r1;
+                b = measure r1;
+            """,
+            [],
+        ),
+        (
+            """
+                qubit["1" ^ "0"] r1;
+            """,
+            [],
+        ),
+        (
+            """
+                bit[1] b;
+                qubit["1" != "0"] r1;
+                b = measure r1;
+            """,
+            [0],
+        ),
+        (
+            """
+                bit[1] b;
+                qubit["1" == "0"] r1;
+                b = measure r1;
+            """,
+            [],
+        ),
+        (
+            """
+                bit[1] b;
+                qubit[1] r1;
+                h r1["0" << "1"];
+                b = measure r1;
+            """,
+            [0],
+        ),
+        (
+            """
+                bit[2] b;
+                qubit[1] r1;
+                h r1["0" >> "1"];
+                b = measure r1;
+            """,
+            [0],
+        ),
+    ],
+)
+def test_circuit_from_string_literal(qasm, expected):
+    circ = Interpreter().build_circuit(source=qasm)
+    assert expected == circ.measured_qubits


### PR DESCRIPTION
*Issue:* #240

*Description of changes:*
Fixes bug [#240] by casting node.size into IntegerLiteral.
Building a circuit from a quasi string raises an `AttributeError` exception in case the qubit register is specified as a string literal.

*Testing done:*
A unit-test is added that checks that the `AttributeError` is not raised anymore.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.