### PR TITLE
fix: fix signed integer casting

### DIFF
--- a/src/braket/default_simulator/openqasm/_helpers/casting.py
+++ b/src/braket/default_simulator/openqasm/_helpers/casting.py
@@ -90,8 +90,10 @@ def _(into: IntType, variable: LiteralType) -> IntegerLiteral:
     else:
         value = variable.value
         if into.size is not None:
-            limit = 2 ** (into.size.value - 1)
-            value = int(np.sign(value) * (np.abs(int(value)) % limit))
+            limit = 2**into.size.value
+            value = int(value) % limit
+            if (value) >= limit / 2:
+                value -= limit
             if value != variable.value:
                 warnings.warn(
                     f"Integer overflow for value {variable.value} and size {into.size.value}."

--- a/src/braket/default_simulator/openqasm/_helpers/casting.py
+++ b/src/braket/default_simulator/openqasm/_helpers/casting.py
@@ -86,7 +86,7 @@ def _(into: IntType, variable: LiteralType) -> IntegerLiteral:
     if isinstance(variable, ArrayLiteral):
         value = int("".join("01"[x.value] for x in variable.values[1:]), base=2)
         if variable.values[0].value:
-            value *= -1
+            value -= 2 ** (len(variable.values) - 1)
     else:
         value = variable.value
         if into.size is not None:

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -186,6 +186,9 @@ def test_signed_int_cast():
     uint[8] y0 = 128;
     int[8] y1 = y0;
     uint[8] y2 = y1;
+
+    int[3] z0 = "100";
+    int[3] z1 = "111";
     """
 
     context = Interpreter().run(qasm)
@@ -197,6 +200,9 @@ def test_signed_int_cast():
     assert context.get_value("y0") == IntegerLiteral(128)
     assert context.get_value("y1") == IntegerLiteral(-128)
     assert context.get_value("y2") == IntegerLiteral(128)
+
+    assert context.get_value("z0") == IntegerLiteral(-4)
+    assert context.get_value("z1") == IntegerLiteral(-1)
 
 
 def test_float_declaration():
@@ -700,7 +706,7 @@ def test_update_bits_int():
     """
     context = Interpreter().run(qasm)
     assert context.get_value("x") == IntegerLiteral(3)
-    assert context.get_value("y") == IntegerLiteral(-2)
+    assert context.get_value("y") == IntegerLiteral(-6)
     assert context.get_value("z") == IntegerLiteral(10)
 
 

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -113,6 +113,8 @@ def test_int_declaration():
     int[8] uninitialized;
     int[8] pos = 10;
     int[5] neg = -4;
+    int[8] int_min = -128;
+    int[8] int_max = 127;
     int[3] pos_overflow = 5;
     int[3] neg_overflow = -6;
     int no_size = 1e9;
@@ -133,8 +135,10 @@ def test_int_declaration():
     assert context.get_value("uninitialized") is None
     assert context.get_value("pos") == IntegerLiteral(10)
     assert context.get_value("neg") == IntegerLiteral(-4)
-    assert context.get_value("pos_overflow") == IntegerLiteral(1)
-    assert context.get_value("neg_overflow") == IntegerLiteral(-2)
+    assert context.get_value("int_min") == IntegerLiteral(-128)
+    assert context.get_value("int_max") == IntegerLiteral(127)
+    assert context.get_value("pos_overflow") == IntegerLiteral(-3)
+    assert context.get_value("neg_overflow") == IntegerLiteral(2)
     assert context.get_value("no_size") == IntegerLiteral(1_000_000_000)
 
     warnings = {(warn.category, warn.message.args[0]) for warn in warn_info}
@@ -171,6 +175,28 @@ def test_uint_declaration():
     assert context.get_value("pos_overflow") == IntegerLiteral(0)
     assert context.get_value("neg_overflow") == IntegerLiteral(7)
     assert context.get_value("no_size") == IntegerLiteral(1_000_000_000)
+
+
+def test_signed_int_cast():
+    qasm = """
+    uint[8] x0 = 255;
+    int[8] x1 = x0;
+    uint[8] x2 = x1;
+
+    uint[8] y0 = 128;
+    int[8] y1 = y0;
+    uint[8] y2 = y1;
+    """
+
+    context = Interpreter().run(qasm)
+
+    assert context.get_value("x0") == IntegerLiteral(255)
+    assert context.get_value("x1") == IntegerLiteral(-1)
+    assert context.get_value("x2") == IntegerLiteral(255)
+
+    assert context.get_value("y0") == IntegerLiteral(128)
+    assert context.get_value("y1") == IntegerLiteral(-128)
+    assert context.get_value("y2") == IntegerLiteral(128)
 
 
 def test_float_declaration():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prior to this change, signed integer casting worked based on sign+magnitude. This change will use two's complement.
* https://openqasm.com/language/types.html#casting-from-int-uint
* https://openqasm.com/language/types.html#casting-from-bit

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
