### PR TITLE
fix: Use csr_matrix.getH() instead of H

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -658,7 +658,7 @@ def _apply_hamiltonian(
         rabi_ops, rabi_coefs, detuning_ops, detuning_coefs
     ):
         output_register += (rabi_coef[index_time] / 2) * rabi_op.dot(input_register)
-        output_register += (np.conj(rabi_coef[index_time]) / 2) * rabi_op.H.dot(input_register)
+        output_register += (np.conj(rabi_coef[index_time]) / 2) * rabi_op.getH().dot(input_register)
         output_register -= detuning_coef[index_time] * detuning_op.dot(input_register)
 
     # Add local detuning


### PR DESCRIPTION
`csr_matrix.H` has been [removed](https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations) in SciPy 1.14.0.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
