### PR TITLE
feat: Make MAX_NET_DETUNING in AHS device capabilities optional and extend field validator utility functions.

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/validators/capabilities_constants.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/validators/capabilities_constants.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
 from decimal import Decimal
+from typing import Optional
 
 from pydantic import PositiveInt
 from pydantic.v1.main import BaseModel
@@ -33,4 +33,4 @@ class CapabilitiesConstants(BaseModel):
 
     MAGNITUDE_PATTERN_VALUE_MIN: Decimal
     MAGNITUDE_PATTERN_VALUE_MAX: Decimal
-    MAX_NET_DETUNING: Decimal
+    MAX_NET_DETUNING: Optional[Decimal]

--- a/src/braket/analog_hamiltonian_simulator/rydberg/validators/field_validator_util.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/validators/field_validator_util.py
@@ -104,3 +104,50 @@ def validate_net_detuning_with_warning(
                 # Return immediately if there is an atom has net detuning
                 # exceeding MAX_NET_DETUNING at a time point
                 return program
+
+
+# Two time points cannot be too close, assuming the time points are sorted ascendingly
+def validate_time_separation(times: List[Decimal], min_time_separation: Decimal, name: str):
+    for i in range(len(times) - 1):
+        time_diff = times[i + 1] - times[i]
+        if time_diff < min_time_separation:
+            raise ValueError(
+                f"Time points of {name} time_series, {i} ({times[i]}) and "
+                f"{i + 1} ({times[i + 1]}), are too close; they are separated "
+                f"by {time_diff} seconds. It must be at least {min_time_separation} seconds"
+            )
+
+
+def validate_value_precision(values: List[Decimal], max_precision: Decimal, name: str):
+    # Raise ValueError if at any item in the values is beyond the max allowable precision
+    for idx, v in enumerate(values):
+        if v % max_precision != 0:
+            raise ValueError(
+                f"Value {idx} ({v}) in {name} time_series is defined with too many digits; "
+                f"it must be an integer multiple of {max_precision}"
+            )
+
+
+def validate_max_absolute_slope(
+    times: List[Decimal], values: List[Decimal], max_slope: Decimal, name: str
+):
+    # Raise ValueError if at any time the time series (times, values)
+    # rises/falls faster than allowed
+    for idx in range(len(values) - 1):
+        slope = (values[idx + 1] - values[idx]) / (times[idx + 1] - times[idx])
+        if abs(slope) > max_slope:
+            raise ValueError(
+                f"For the {name} field, rate of change of values "
+                f"(between the {idx}-th and the {idx + 1}-th times) "
+                f"is {abs(slope)}, more than {max_slope}"
+            )
+
+
+def validate_time_precision(times: List[Decimal], time_precision: Decimal, name: str):
+    for idx, t in enumerate(times):
+        if t % time_precision != 0:
+            raise ValueError(
+                f"time point {idx} ({t}) of {name} time_series is "
+                f"defined with too many digits; it must be an "
+                f"integer multiple of {time_precision}"
+            )

--- a/src/braket/analog_hamiltonian_simulator/rydberg/validators/program.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/validators/program.py
@@ -61,7 +61,7 @@ class ProgramValidator(Program):
         # If no local detuning, we simply return the values
         # because there are separate validators to validate
         # the global driving fields in the program
-        if not len(local_detuning):
+        if not len(local_detuning) or not capabilities.MAX_NET_DETUNING:
             return values
 
         detuning_times = [

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_validator/validators/test_field_validator_utils.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_validator/validators/test_field_validator_utils.py
@@ -1,0 +1,144 @@
+from decimal import Decimal
+
+import pytest
+
+from braket.analog_hamiltonian_simulator.rydberg.validators.field_validator_util import (
+    validate_max_absolute_slope,
+    validate_time_precision,
+    validate_time_separation,
+    validate_value_precision,
+)
+
+
+@pytest.mark.parametrize(
+    "times, min_time_separation, fail",
+    [
+        (
+            [Decimal("0.0"), Decimal("1e-5"), Decimal("2e-5"), Decimal("2.5"), Decimal("4")],
+            Decimal("1e-3"),
+            True,
+        ),
+        (
+            [Decimal("0.0"), Decimal("1e-5"), Decimal("2e-5"), Decimal("2.5"), Decimal("4")],
+            Decimal("1e-6"),
+            False,
+        ),
+        (
+            [Decimal("0.0"), Decimal("1"), Decimal("2"), Decimal("3"), Decimal("4")],
+            Decimal("1e-3"),
+            False,
+        ),
+    ],
+)
+def test_validate_time_separation(times, min_time_separation, fail):
+    if fail:
+        with pytest.raises(ValueError):
+            validate_time_separation(times, min_time_separation, "test")
+    else:
+        try:
+            validate_time_separation(times, min_time_separation, "test")
+        except ValueError as e:
+            pytest.fail(f"Failed valid validate_min_time_separation: {str(e)}")
+
+
+@pytest.mark.parametrize(
+    "values, max_precision, fail",
+    [
+        (
+            [Decimal("0.0"), Decimal("1e-5"), Decimal("2e-5"), Decimal("2.5"), Decimal("4")],
+            Decimal("1e-3"),
+            True,
+        ),
+        (
+            [Decimal("0.0"), Decimal("1e-9"), Decimal("2e-5"), Decimal("3e-4"), Decimal("5.0")],
+            Decimal("1e-6"),
+            True,
+        ),
+        (
+            [
+                Decimal("0.0"),
+                Decimal("0.00089"),
+                Decimal("2e-4"),
+                Decimal("0.003"),
+                Decimal("0.21"),
+                Decimal("1"),
+            ],
+            Decimal("1e-5"),
+            False,
+        ),
+    ],
+)
+def test_validate_value_precision(values, max_precision, fail):
+    if fail:
+        with pytest.raises(ValueError):
+            validate_value_precision(values, max_precision, "test")
+    else:
+        try:
+            validate_value_precision(values, max_precision, "test")
+        except ValueError as e:
+            pytest.fail(f"Failed valid validate_value_precision: {str(e)}")
+
+
+@pytest.mark.parametrize(
+    "times, values, max_slope, fail",
+    [
+        (
+            [Decimal("0.0"), Decimal("1.0"), Decimal("2.0"), Decimal("3.0")],
+            [Decimal("0.0"), Decimal("2.1"), Decimal("3.2"), Decimal("3.9")],
+            Decimal("2.0"),
+            True,
+        ),
+        (
+            [Decimal("0.0"), Decimal("1e-5"), Decimal("2e-5"), Decimal("3")],
+            [Decimal("0.0"), Decimal("1.2"), Decimal("2.34"), Decimal("2.39")],
+            Decimal("1.5e5"),
+            False,
+        ),
+        (
+            [Decimal("0.0"), Decimal("1.0"), Decimal("2e-5"), Decimal("3")],
+            [Decimal("0.0"), Decimal("1.2"), Decimal("2.34"), Decimal("2.39")],
+            Decimal("1e4"),
+            False,
+        ),
+    ],
+)
+def test_validate_max_absolute_slope(times, values, max_slope, fail):
+    if fail:
+        with pytest.raises(ValueError):
+            validate_max_absolute_slope(times, values, max_slope, "test")
+    else:
+        try:
+            validate_max_absolute_slope(times, values, max_slope, "test")
+        except ValueError as e:
+            pytest.fail(f"Failed valid validate_max_absolute_slope: {str(e)}")
+
+
+@pytest.mark.parametrize(
+    "times, max_precision, fail",
+    [
+        (
+            [Decimal("0.0"), Decimal("1e-5"), Decimal("2e-5"), Decimal("2.5"), Decimal("4")],
+            Decimal("1.3"),
+            True,
+        ),
+        (
+            [Decimal("0.0"), Decimal("1e-9"), Decimal("2e-5"), Decimal("3e-4"), Decimal("5.0")],
+            Decimal("1e-6"),
+            True,
+        ),
+        (
+            [Decimal("0"), Decimal("1e-07"), Decimal("3.9e-06"), Decimal("4e-06")],
+            Decimal("1e-09"),
+            False,
+        ),
+    ],
+)
+def test_validate_time_precision(times, max_precision, fail):
+    if fail:
+        with pytest.raises(ValueError):
+            validate_time_precision(times, max_precision, "test")
+    else:
+        try:
+            validate_time_precision(times, max_precision, "test")
+        except ValueError as e:
+            pytest.fail(f"Failed valid validate_min_time_precision: {str(e)}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make the MAX_NET_DETUNING device capability data point optional for AHS program validation - this is done so the Program validator used for AHS programs with the local simulator can also be used with capabilities derived from QPU capabilities, which don't provide a MAX_NET_DETUNING data point. 

Additionally, utility methods `validate_max_absolute_slope`,`validate_time_precision`,`validate_time_separation`,`validate_value_precision` are added to field validator utilities for use AHS Program validation with Device Capabilities Constants (introduced in BDK). 

*Testing done:*
Tested the newly introduced field validation utility functions.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
