### PR TITLE
fix: change numpy tostring to tobytes

### DIFF
--- a/src/braket/default_simulator/simulator.py
+++ b/src/braket/default_simulator/simulator.py
@@ -367,7 +367,7 @@ class BaseLocalSimulator(OpenQASMSimulator):
     @staticmethod
     def _observable_hash(observable: Observable) -> Union[str, dict[int, str]]:
         if isinstance(observable, Hermitian):
-            return str(hash(str(observable.matrix.tostring())))
+            return str(hash(str(observable.matrix.tobytes())))
         elif isinstance(observable, TensorProduct):
             # Dict of target index to observable hash
             return BaseLocalSimulator._tensor_product_index_dict(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://numpy.org/doc/2.1/reference/generated/numpy.ndarray.tostring.html - tostring is gone, using `tobytes` instead

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
