### PR TITLE
fix: Pass username to testenv

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,10 +16,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          # Weird filesystem issues in Windows runner
-          - os: windows-latest
-            python-version: 3.13
 
     steps:
     - uses: actions/checkout@v5

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "test": [
             "pre-commit",
             "pylint",
-            "pytest",
+            "pytest==7.4.4",
             "pytest-benchmark",
             "pytest-cov",
             "pytest-rerunfailures",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "test": [
             "pre-commit",
             "pylint",
-            "pytest==7.2.0",
+            "pytest",
             "pytest-benchmark",
             "pytest-cov",
             "pytest-rerunfailures",
@@ -70,7 +70,7 @@ setup(
     url="https://github.com/amazon-braket/amazon-braket-default-simulator-python",
     author="Amazon Web Services",
     description=(
-        "An open source quantum circuit simulator to be run locally with the Amazon Braket SDK"
+        "An open source quantum program simulator to be run locally with the Amazon Braket SDK"
     ),
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tox.ini
+++ b/tox.ini
@@ -80,4 +80,9 @@ extras = test
 deps =
     # If you need to test on a certain branch, add @<branch-name> after .git
     git+https://github.com/amazon-braket/amazon-braket-schemas-python.git
-    
+
+[testenv]
+# Python 3.13 tests on Windows break without this
+# see https://github.com/gitpython-developers/GitPython/issues/356#issuecomment-552403929
+# TODO: Delete after unpinning pytest
+passenv = USERNAME


### PR DESCRIPTION
This fixes the test errors for Windows with Python 3.13; before this fix, pytest would break with the error
```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "C:\Users\cody\anaconda3\Lib\getpass.py", line 172, in getuser
INTERNALERROR>     import pwd
INTERNALERROR> ModuleNotFoundError: No module named 'pwd'
INTERNALERROR>
INTERNALERROR> The above exception was the direct cause of the following exception:
INTERNALERROR>
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\_pytest\main.py", line 269, in wrap_session
INTERNALERROR>     config.hook.pytest_sessionstart(session=session)
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_hooks.py", line 512, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_callers.py", line 167, in _multicall
INTERNALERROR>     raise exception
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_callers.py", line 139, in _multicall
INTERNALERROR>     teardown.throw(exception)
INTERNALERROR>     ~~~~~~~~~~~~~~^^^^^^^^^^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_callers.py", line 53, in run_old_style_hookwrapper
INTERNALERROR>     return result.get_result()
INTERNALERROR>            ~~~~~~~~~~~~~~~~~^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_result.py", line 103, in get_result
INTERNALERROR>     raise exc.with_traceback(tb)
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_callers.py", line 38, in run_old_style_hookwrapper
INTERNALERROR>     res = yield
INTERNALERROR>           ^^^^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\pluggy\_callers.py", line 121, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\xdist\dsession.py", line 90, in pytest_sessionstart
INTERNALERROR>     nodes = self.nodemanager.setup_nodes(putevent=self.queue.put)
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\xdist\workermanage.py", line 97, in setup_nodes
INTERNALERROR>     return [self.setup_node(spec, putevent) for spec in self.specs]
INTERNALERROR>             ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\xdist\workermanage.py", line 112, in setup_node
INTERNALERROR>     node.setup()
INTERNALERROR>     ~~~~~~~~~~^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\xdist\workermanage.py", line 340, in setup
INTERNALERROR>     basetemp = self.config._tmp_path_factory.getbasetemp()
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\_pytest\tmpdir.py", line 162, in getbasetemp
INTERNALERROR>     user = get_user() or "unknown"
INTERNALERROR>            ~~~~~~~~^^
INTERNALERROR>   File "C:\Users\cody\GitHub\amazon-braket-default-simulator-python\.tox\unit-tests\Lib\site-packages\_pytest\tmpdir.py", line 211, in get_user
INTERNALERROR>     return getpass.getuser()
INTERNALERROR>            ~~~~~~~~~~~~~~~^^
INTERNALERROR>   File "C:\Users\cody\anaconda3\Lib\getpass.py", line 175, in getuser
INTERNALERROR>     raise OSError('No username set in the environment') from e
INTERNALERROR> OSError: No username set in the environment
```

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
