### PR TITLE
feat: Add tests to make sure the simulator can handle `barrier` instructions

### DIFF
--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -22,6 +22,8 @@ import sympy
 from sympy import Symbol
 
 from braket.default_simulator import StateVectorSimulation
+from braket.default_simulator.openqasm.parser import openqasm_parser
+from braket.default_simulator.openqasm.parser.openqasm_ast import QuantumBarrier
 from braket.default_simulator.openqasm.interpreter import VerbatimBoxDelimiter
 from braket.default_simulator.gate_operations import CX, GPhase, Hadamard, PauliX
 from braket.default_simulator.gate_operations import PauliY as Y
@@ -2305,3 +2307,89 @@ def test_verbatim_wo_box():
         ValueError, match="braket verbatim pragma must be followed by a box statement"
     ):
         Interpreter().run(qasm_without_box)
+
+
+def test_barrier_no_op():
+    """Test barriers are no-ops and don't affect circuit execution."""
+    with_barriers = """
+    qubit[2] q;
+    h q[0];
+    barrier q[0], q[1];
+    cnot q[0], q[1];
+    barrier;
+    x q[1];
+    """
+
+    without_barriers = """
+    qubit[2] q;
+    h q[0];
+    cnot q[0], q[1];
+    x q[1];
+    """
+
+    circuit_with = Interpreter().build_circuit(with_barriers)
+    circuit_without = Interpreter().build_circuit(without_barriers)
+    assert circuit_with == circuit_without
+
+    simulation = StateVectorSimulation(2, 1, 1)
+    simulation.evolve(circuit_with.instructions)
+    expected_state = simulation.state_vector.copy()
+
+    simulation = StateVectorSimulation(2, 1, 1)
+    simulation.evolve(circuit_without.instructions)
+    assert np.allclose(simulation.state_vector, expected_state)
+
+
+def test_barrier_syntax():
+    """Test various barrier syntaxes are accepted."""
+    qasm = """
+    qubit[3] q;
+    barrier q[0];
+    barrier q[0], q[1];
+    barrier q;
+    barrier;
+    """
+    circuit = Interpreter().build_circuit(qasm)
+    assert len(circuit.instructions) == 0
+
+
+def test_barrier_with_gates():
+    """Test barriers don't interfere with gate execution."""
+    qasm = """
+    qubit[2] q;
+    h q[0];
+    barrier q;
+    cnot q[0], q[1];
+    barrier q[1];
+    x q[0];
+    """
+
+    circuit = Interpreter().build_circuit(qasm)
+    assert len(circuit.instructions) == 3
+    assert isinstance(circuit.instructions[0], Hadamard)
+    assert isinstance(circuit.instructions[1], CX)
+    assert isinstance(circuit.instructions[2], PauliX)
+
+    simulation = StateVectorSimulation(2, 1, 1)
+    simulation.evolve(circuit.instructions)
+    assert np.allclose(simulation.state_vector, [0, 1 / np.sqrt(2), 1 / np.sqrt(2), 0])
+
+
+def test_barrier_parsing_specific_qubits():
+    """Test barrier parsing creates correct AST nodes."""
+    qasm = "qubit[2] q; barrier q[0], q[1];"
+    program = openqasm_parser.parse(qasm)
+    barrier_stmt = program.statements[1]
+
+    assert isinstance(barrier_stmt, QuantumBarrier)
+    assert len(barrier_stmt.qubits) == 2
+
+
+def test_barrier_global():
+    """Test global barrier without specific qubits."""
+    qasm = "qubit[2] q; barrier;"
+    program = openqasm_parser.parse(qasm)
+    barrier_stmt = program.statements[1]
+
+    assert isinstance(barrier_stmt, QuantumBarrier)
+    assert len(barrier_stmt.qubits) == 0  # Empty means all qubits


### PR DESCRIPTION
*Description of changes:* Multiple tests are added to make sure that the local simulator can interpret `barrier` instructions in an openqasm file.

*Testing done:* tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
