### PR TITLE
fix: Rearrange density matrix right multiplication

### DIFF
--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -30,7 +30,7 @@ nb.config.CAPTURED_ERRORS = "new_style"
 
 _NEG_CONTROL_SLICE = slice(None, 1)
 _CONTROL_SLICE = slice(1, None)
-_NO_CONTROL_SLICE = slice(None, None)
+_NO_CONTROL_SLICE = slice(None)
 
 BASIS_MAPPING = {0: (0, 0), 1: (0, 1), 2: (1, 0), 3: (1, 1)}
 
@@ -495,9 +495,9 @@ def _apply_cnot_small(
     """CNOT optimization path."""
     n_qubits = state.ndim
 
-    slice_list = [slice(None)] * n_qubits
+    slice_list = [_NO_CONTROL_SLICE] * n_qubits
 
-    slice_list[control] = 1
+    slice_list[control] = _CONTROL_SLICE
     slice_list[target] = 0
     slices_c1t0 = tuple(slice_list)
 
@@ -643,7 +643,7 @@ def _apply_controlled_phase_shift_small(
     state: np.ndarray, phase_factor: complex, controls, target: int
 ) -> tuple[np.ndarray, bool]:
     """C Phase shift gate optimization path for smaller vectors using numpy slicing."""
-    slices = [slice(None)] * len(state.shape)
+    slices = [_NO_CONTROL_SLICE] * len(state.shape)
     for c in controls:
         slices[c] = 1
     slices[target] = 1
@@ -711,7 +711,7 @@ def _apply_two_qubit_gate_small(
 
     slices = {}
     for bits in [(0, 0), (0, 1), (1, 0), (1, 1)]:
-        slice_list = [slice(None)] * n_qubits
+        slice_list = [_NO_CONTROL_SLICE] * n_qubits
         slice_list[target0] = bits[0]
         slice_list[target1] = bits[1]
         slices[bits] = tuple(slice_list)

--- a/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
@@ -467,6 +467,21 @@ def bell_ir_with_result(ir_type):
     return _bell_ir_with_result
 
 
+def test_ghz_0():
+    qasm = """
+    qubit[4] q;
+    h q[0];
+    cnot q[0], q[1];
+    cnot q[0], q[2];
+    ctrl @ x q[0], q[3];
+    #pragma braket result probability
+    """
+    simulator = DensityMatrixSimulator()
+    result = simulator.run(OpenQASMProgram(source=qasm))
+    probs = result.resultTypes[0].value
+    assert np.allclose(probs, np.array([0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.5]))
+
+
 def test_gphase():
     qasm = """
     qubit[2] qs;


### PR DESCRIPTION
This fixes a control modifiers bug and allows us to use CNot dispatch for right multiplication

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
