### PR TITLE
feat: interpreter improvements, measure and reset

### DIFF
--- a/src/braket/default_simulator/gate_operations.py
+++ b/src/braket/default_simulator/gate_operations.py
@@ -1295,15 +1295,7 @@ class Measure(GateOperation):
 
     @property
     def _base_matrix(self) -> np.ndarray:
-        """Return the projection matrix for the measurement outcome (0 or 1)."""
-        if self.result == 0:
-            # Project to |0⟩⟨0|
-            return np.array([[1, 0], [0, 0]], dtype=complex)
-        elif self.result == 1:
-            # Project to |1⟩⟨1|
-            return np.array([[0, 0], [0, 1]], dtype=complex)
-        else:
-            raise ValueError(f"Invalid measurement result: {self.result}. Must be 0 or 1.")
+        raise NotImplementedError("Measure does not have a matrix implementation")
 
     def apply(self, state: np.ndarray) -> np.ndarray:
         if self.result == -1:

--- a/src/braket/default_simulator/gate_operations.py
+++ b/src/braket/default_simulator/gate_operations.py
@@ -1281,6 +1281,106 @@ class GPhase(GateOperation):
         return "gphase"
 
 
+class Measure(GateOperation):
+    """
+    Measurement operation that projects the state to a specific outcome.
+
+    This is used in branched simulation to apply measurement projections
+    when recalculating states from instruction sequences.
+    """
+
+    def __init__(self, targets: Sequence[int], result: int = -1):
+        super().__init__(targets=targets)
+        self.result = result  # The measurement outcome (0 or 1)
+
+    @property
+    def _base_matrix(self) -> np.ndarray:
+        """
+        Return the projection matrix for the measurement outcome.
+        If result is -1 (unset), return identity (no projection).
+        """
+        if self.result == -1:
+            return np.eye(2)
+        elif self.result == 0:
+            # Project to |0⟩⟨0|
+            return np.array([[1, 0], [0, 0]], dtype=complex)
+        elif self.result == 1:
+            # Project to |1⟩⟨1|
+            return np.array([[0, 0], [0, 1]], dtype=complex)
+        else:
+            return np.eye(2)
+
+    def apply(self, state: np.ndarray) -> np.ndarray:
+        if self.result == -1:
+            return state
+
+        # Apply projection matrix
+        projected_state = state.copy()
+
+        # For single qubit measurement, we need to project the appropriate amplitudes
+        if len(self._targets) == 1:
+            qubit_idx = self._targets[0]
+            n_qubits = int(np.log2(len(state)))
+
+            # Create mask for the target qubit
+            mask = 1 << (n_qubits - qubit_idx - 1)  # Big-endian indexing
+
+            # Zero out amplitudes that don't match the measurement result
+            for i in range(len(projected_state)):
+                qubit_value = (i & mask) >> (n_qubits - qubit_idx - 1)
+                if qubit_value != self.result:
+                    projected_state[i] = 0
+
+            # Normalize the state
+            norm = np.linalg.norm(projected_state)
+            if norm > 0:
+                projected_state /= norm
+
+        return projected_state
+
+
+class Reset(GateOperation):
+    """
+    Reset operation that sets desired target to 0
+    """
+
+    def __init__(self, targets: Sequence[int]):
+        super().__init__(targets=targets)
+
+    @property
+    def _base_matrix(self) -> np.ndarray:
+        raise NotImplementedError("Reset does not have a matrix implementation")
+
+    def apply(self, state: np.ndarray) -> np.ndarray:
+
+        # For single qubit measurement, we need to project the appropriate amplitudes
+        if len(self._targets) == 1:
+            qubit_idx = self._targets[0]
+            n_qubits = int(np.log2(len(state)))
+
+            # Create mask for the target qubit
+            mask = 1 << (n_qubits - qubit_idx - 1)  # Big-endian indexing
+
+            for i in range(len(state)):
+                # Check if the qubit is in state 1
+                qubit_value = (i & mask) >> (n_qubits - qubit_idx - 1)
+                if qubit_value == 1:
+                    zero_index = i & ~mask
+
+                    # Transfer the amplitude (with proper scaling)
+                    state[zero_index] += state[i]
+
+                    # Set the original amplitude to zero
+                    state[i] = 0
+
+            # Normalize the state
+            norm = np.linalg.norm(state)
+            if norm > 0:
+                state /= norm
+
+        return state
+
+
 BRAKET_GATES = {
     "i": Identity,
     "h": Hadamard,

--- a/src/braket/default_simulator/gate_operations.py
+++ b/src/braket/default_simulator/gate_operations.py
@@ -1347,31 +1347,31 @@ class Reset(GateOperation):
         raise NotImplementedError("Reset does not have a matrix implementation")
 
     def apply(self, state: np.ndarray) -> np.ndarray:
+        if len(self._targets) != 1:
+            raise ValueError(f"Reset only supports a single target qubit, got {len(self._targets)}.")
 
-        # For single qubit measurement, we need to project the appropriate amplitudes
-        if len(self._targets) == 1:
-            qubit_idx = self._targets[0]
-            n_qubits = int(np.log2(len(state)))
+        qubit_idx = self._targets[0]
+        n_qubits = int(np.log2(len(state)))
 
-            # Create mask for the target qubit
-            mask = 1 << (n_qubits - qubit_idx - 1)  # Big-endian indexing
+        # Create mask for the target qubit
+        mask = 1 << (n_qubits - qubit_idx - 1)  # Big-endian indexing
 
-            for i in range(len(state)):
-                # Check if the qubit is in state 1
-                qubit_value = (i & mask) >> (n_qubits - qubit_idx - 1)
-                if qubit_value == 1:
-                    zero_index = i & ~mask
+        for i in range(len(state)):
+            # Check if the qubit is in state 1
+            qubit_value = (i & mask) >> (n_qubits - qubit_idx - 1)
+            if qubit_value == 1:
+                zero_index = i & ~mask
 
-                    # Transfer the amplitude (with proper scaling)
-                    state[zero_index] += state[i]
+                # Transfer the amplitude (with proper scaling)
+                state[zero_index] += state[i]
 
-                    # Set the original amplitude to zero
-                    state[i] = 0
+                # Set the original amplitude to zero
+                state[i] = 0
 
-            # Normalize the state
-            norm = np.linalg.norm(state)
-            if norm > 0:
-                state /= norm
+        # Normalize the state
+        norm = np.linalg.norm(state)
+        if norm > 0:
+            state /= norm
 
         return state
 

--- a/src/braket/default_simulator/gate_operations.py
+++ b/src/braket/default_simulator/gate_operations.py
@@ -1295,20 +1295,15 @@ class Measure(GateOperation):
 
     @property
     def _base_matrix(self) -> np.ndarray:
-        """
-        Return the projection matrix for the measurement outcome.
-        If result is -1 (unset), return identity (no projection).
-        """
-        if self.result == -1:
-            return np.eye(2)
-        elif self.result == 0:
+        """Return the projection matrix for the measurement outcome (0 or 1)."""
+        if self.result == 0:
             # Project to |0⟩⟨0|
             return np.array([[1, 0], [0, 0]], dtype=complex)
         elif self.result == 1:
             # Project to |1⟩⟨1|
             return np.array([[0, 0], [0, 1]], dtype=complex)
         else:
-            return np.eye(2)
+            raise ValueError(f"Invalid measurement result: {self.result}. Must be 0 or 1.")
 
     def apply(self, state: np.ndarray) -> np.ndarray:
         if self.result == -1:

--- a/src/braket/default_simulator/gate_operations.py
+++ b/src/braket/default_simulator/gate_operations.py
@@ -1309,27 +1309,27 @@ class Measure(GateOperation):
         if self.result == -1:
             return state
 
+        if len(self._targets) != 1:
+            raise ValueError(f"Measure only supports a single target qubit, got {len(self._targets)}.")
+
         # Apply projection matrix
         projected_state = state.copy()
+        qubit_idx = self._targets[0]
+        n_qubits = int(np.log2(len(state)))
 
-        # For single qubit measurement, we need to project the appropriate amplitudes
-        if len(self._targets) == 1:
-            qubit_idx = self._targets[0]
-            n_qubits = int(np.log2(len(state)))
+        # Create mask for the target qubit
+        mask = 1 << (n_qubits - qubit_idx - 1)  # Big-endian indexing
 
-            # Create mask for the target qubit
-            mask = 1 << (n_qubits - qubit_idx - 1)  # Big-endian indexing
+        # Zero out amplitudes that don't match the measurement result
+        for i in range(len(projected_state)):
+            qubit_value = (i & mask) >> (n_qubits - qubit_idx - 1)
+            if qubit_value != self.result:
+                projected_state[i] = 0
 
-            # Zero out amplitudes that don't match the measurement result
-            for i in range(len(projected_state)):
-                qubit_value = (i & mask) >> (n_qubits - qubit_idx - 1)
-                if qubit_value != self.result:
-                    projected_state[i] = 0
-
-            # Normalize the state
-            norm = np.linalg.norm(projected_state)
-            if norm > 0:
-                projected_state /= norm
+        # Normalize the state
+        norm = np.linalg.norm(projected_state)
+        if norm > 0:
+            projected_state /= norm
 
         return projected_state
 

--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -56,6 +56,7 @@ from ._helpers.quantum import (
 from .circuit import Circuit
 from .parser.openqasm_ast import (
     AccessControl,
+    AliasStatement,
     ArrayLiteral,
     ArrayReferenceType,
     ArrayType,
@@ -64,15 +65,20 @@ from .parser.openqasm_ast import (
     BitstringLiteral,
     BitType,
     BooleanLiteral,
+    BoolType,
     Box,
     BranchingStatement,
+    BreakStatement,
     Cast,
     ClassicalArgument,
     ClassicalAssignment,
     ClassicalDeclaration,
+    Concatenation,
     ConstantDeclaration,
+    ContinueStatement,
     DiscreteSet,
     FloatLiteral,
+    FloatType,
     ForInLoop,
     FunctionCall,
     GateModifierName,
@@ -81,6 +87,7 @@ from .parser.openqasm_ast import (
     IndexedIdentifier,
     IndexExpression,
     IntegerLiteral,
+    IntType,
     IODeclaration,
     IOKeyword,
     Pragma,
@@ -101,11 +108,12 @@ from .parser.openqasm_ast import (
     SizeOf,
     SubroutineDefinition,
     SymbolLiteral,
+    UintType,
     UnaryExpression,
     WhileLoop,
 )
 from .parser.openqasm_parser import parse
-from .program_context import AbstractProgramContext, ProgramContext
+from .program_context import AbstractProgramContext, ProgramContext, _BreakSignal, _ContinueSignal
 
 
 class Interpreter:
@@ -196,6 +204,12 @@ class Interpreter:
             init_value = create_empty_array(node_type.dimensions)
         elif isinstance(node_type, BitType) and node_type.size:
             init_value = create_empty_array([node_type.size])
+        elif isinstance(node_type, (IntType, UintType)):
+            init_value = IntegerLiteral(value=0)
+        elif isinstance(node_type, FloatType):
+            init_value = FloatLiteral(value=0.0)
+        elif isinstance(node_type, BoolType):
+            init_value = BooleanLiteral(value=False)
         else:
             init_value = None
         self.context.declare_variable(node.identifier.name, node_type, init_value)
@@ -265,7 +279,7 @@ class Interpreter:
 
     @visit.register
     def _(self, node: QuantumReset) -> None:
-        raise NotImplementedError("Reset not supported")
+        self.context.add_reset(list(self.context.get_qubits(self.visit(node.qubits))))
 
     @visit.register
     def _(self, node: QuantumBarrier) -> None:
@@ -511,7 +525,6 @@ class Interpreter:
 
     @visit.register
     def _(self, node: QuantumMeasurementStatement) -> None:
-        """The measure is performed but the assignment is ignored"""
         qubits = self.visit(node.measure)
         targets = []
         if node.target and isinstance(node.target, IndexedIdentifier):
@@ -528,7 +541,8 @@ class Interpreter:
                     self._uses_advanced_language_features = True
                     targets.extend(convert_range_def_to_range(self.visit(elem)))
                 case _:
-                    targets.append(elem.value)
+                    resolved = self.visit(elem) if isinstance(elem, Identifier) else elem
+                    targets.append(resolved.value)
 
         if not len(targets):
             targets = None
@@ -566,8 +580,10 @@ class Interpreter:
     def _(self, node: BranchingStatement) -> None:
         self._uses_advanced_language_features = True
         condition = cast_to(BooleanLiteral, self.visit(node.condition))
-        for statement in node.if_block if condition.value else node.else_block:
-            self.visit(statement)
+        if condition.value:
+            self.visit(node.if_block)
+        elif node.else_block:
+            self.visit(node.else_block)
 
     @visit.register
     def _(self, node: ForInLoop) -> None:
@@ -578,16 +594,53 @@ class Interpreter:
         # DiscreteSet
         else:
             index_values = index.values
+
+        loop_var_name = node.identifier.name
         for i in index_values:
             with self.context.enter_scope():
-                self.context.declare_variable(node.identifier.name, node.type, i)
-                self.visit(deepcopy(node.block))
+                self.context.declare_variable(loop_var_name, node.type, i)
+                try:
+                    self.visit(deepcopy(node.block))
+                except _BreakSignal:
+                    break
+                except _ContinueSignal:
+                    continue
 
     @visit.register
     def _(self, node: WhileLoop) -> None:
         self._uses_advanced_language_features = True
-        while cast_to(BooleanLiteral, self.visit(deepcopy(node.while_condition))).value:
-            self.visit(deepcopy(node.block))
+        while cast_to(BooleanLiteral, self.visit(node.while_condition)).value:
+            try:
+                self.visit(deepcopy(node.block))
+            except _BreakSignal:
+                break
+            except _ContinueSignal:
+                continue
+
+    @visit.register
+    def _(self, node: BreakStatement) -> None:
+        raise _BreakSignal()
+
+    @visit.register
+    def _(self, node: ContinueStatement) -> None:
+        raise _ContinueSignal()
+
+    @visit.register
+    def _(self, node: AliasStatement) -> None:
+        """Handle alias statements (let q1 = q, let combined = q1 ++ q2)."""
+        alias_name = node.target.name
+        if isinstance(node.value, Identifier):
+            # Simple alias: let q1 = q
+            self.context.qubit_mapping[alias_name] = self.context.get_qubits(node.value)
+            self.context.declare_qubit_alias(alias_name, node.value)
+        elif isinstance(node.value, Concatenation):
+            # Concatenation alias: let combined = q1 ++ q2
+            lhs_qubits = tuple(self.context.get_qubits(node.value.lhs))
+            rhs_qubits = tuple(self.context.get_qubits(node.value.rhs))
+            self.context.qubit_mapping[alias_name] = lhs_qubits + rhs_qubits
+            self.context.declare_qubit_alias(alias_name, Identifier(alias_name))
+        else:
+            raise NotImplementedError(f"Alias with {type(node.value).__name__} is not supported")
 
     @visit.register
     def _(self, node: Include) -> None:

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -19,7 +19,7 @@ from typing import Any
 import numpy as np
 from sympy import Expr
 
-from braket.default_simulator.gate_operations import BRAKET_GATES, GPhase, Unitary
+from braket.default_simulator.gate_operations import BRAKET_GATES, GPhase, Reset, Unitary
 from braket.default_simulator.noise_operations import (
     AmplitudeDamping,
     BitFlip,
@@ -850,6 +850,15 @@ class AbstractProgramContext(ABC):
                 applies to all qubits in the circuit.
         """
 
+    def add_reset(self, target: list[int]) -> None:
+        """Add a reset instruction to the circuit.
+
+        Resets the specified qubits to the |0⟩ state.
+
+        Args:
+            target (list[int]): The target qubits to reset.
+        """
+
     def add_verbatim_marker(self, marker) -> None:
         """Add verbatim markers"""
 
@@ -916,3 +925,15 @@ class ProgramContext(AbstractProgramContext):
 
     def add_measure(self, target: tuple[int], classical_targets: Iterable[int] | None = None):
         self._circuit.add_measure(target, classical_targets)
+
+    def add_reset(self, target: list[int]) -> None:
+        for qubit in target:
+            self._circuit.add_instruction(Reset(targets=(qubit,)))
+
+
+class _BreakSignal(Exception):
+    """Internal signal raised when a BreakStatement is encountered during execution."""
+
+
+class _ContinueSignal(Exception):
+    """Internal signal raised when a ContinueStatement is encountered during execution."""

--- a/src/braket/default_simulator/simulation_strategies/batch_operation_strategy.py
+++ b/src/braket/default_simulator/simulation_strategies/batch_operation_strategy.py
@@ -53,6 +53,7 @@ def apply_operations(
     # TODO: Write algorithm to determine partition size based on operations and qubit count
     partitions = [operations[i : i + batch_size] for i in range(0, len(operations), batch_size)]
 
+    # TODO: support MCM
     for partition in partitions:
         state = _contract_operations(state, qubit_count, partition)
 

--- a/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
+++ b/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
@@ -13,6 +13,7 @@
 
 import numpy as np
 
+from braket.default_simulator.gate_operations import Measure, Reset
 from braket.default_simulator.linalg_utils import QuantumGateDispatcher, multiply_matrix
 from braket.default_simulator.operation import GateOperation
 
@@ -35,19 +36,25 @@ def apply_operations(
 
     dispatcher = QuantumGateDispatcher(state.ndim)
     for op in operations:
-        targets = op.targets
-        num_ctrl = len(op.control_state)
-        _, needs_swap = multiply_matrix(
-            result,
-            op.matrix,
-            targets[num_ctrl:],
-            targets[:num_ctrl],
-            op.control_state,
-            temp,
-            dispatcher,
-            True,
-            gate_type=op.gate_type,
-        )
-        if needs_swap:
-            result, temp = temp, result
+        if isinstance(op, (Measure, Reset)):
+            # Reshape to 1D for Measure.apply, then back to tensor form
+            result_1d = np.reshape(result, 2 ** len(result.shape))
+            result_1d = op.apply(result_1d)  # type: ignore
+            result = np.reshape(result_1d, result.shape)
+        else:
+            targets = op.targets
+            num_ctrl = len(op.control_state)
+            _, needs_swap = multiply_matrix(
+                result,
+                op.matrix,
+                targets[num_ctrl:],
+                targets[:num_ctrl],
+                op.control_state,
+                temp,
+                dispatcher,
+                True,
+                gate_type=op.gate_type,
+            )
+            if needs_swap:
+                result, temp = temp, result
     return result

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -2467,3 +2467,124 @@ def test_barrier_visitor_mixed_with_gates():
     assert isinstance(circuit.instructions[0], Hadamard)
     assert isinstance(circuit.instructions[1], CX)
     assert isinstance(circuit.instructions[2], PauliX)
+
+
+def test_if_else_branch():
+    # exercises the else_block path in BranchingStatement
+    qasm = """
+    int[8] x = 0;
+    if (false) {
+        x = 1;
+    } else {
+        x = 2;
+    }
+    """
+    context = Interpreter().run(qasm)
+    assert context.get_value("x") == IntegerLiteral(2)
+
+
+def test_for_loop_break():
+    # exercises _BreakSignal / BreakStatement
+    qasm = """
+    int[8] x = 0;
+    for int[8] i in [0:4] {
+        if (i == 2) {
+            break;
+        }
+        x += 1;
+    }
+    """
+    context = Interpreter().run(qasm)
+    assert context.get_value("x") == IntegerLiteral(2)
+
+
+def test_for_loop_continue():
+    # exercises _ContinueSignal / ContinueStatement
+    qasm = """
+    int[8] x = 0;
+    for int[8] i in [0:4] {
+        if (i == 2) {
+            continue;
+        }
+        x += 1;
+    }
+    """
+    context = Interpreter().run(qasm)
+    assert context.get_value("x") == IntegerLiteral(4)
+
+
+def test_while_loop_break():
+    qasm = """
+    int[8] x = 0;
+    int[8] i = 0;
+    while (i < 10) {
+        if (i == 3) {
+            break;
+        }
+        x += 1;
+        i += 1;
+    }
+    """
+    context = Interpreter().run(qasm)
+    assert context.get_value("x") == IntegerLiteral(3)
+
+
+def test_while_loop_continue():
+    qasm = """
+    int[8] x = 0;
+    int[8] i = 0;
+    while (i < 5) {
+        i += 1;
+        if (i == 3) {
+            continue;
+        }
+        x += 1;
+    }
+    """
+    context = Interpreter().run(qasm)
+    assert context.get_value("x") == IntegerLiteral(4)
+
+
+def test_alias_simple():
+    # exercises AliasStatement with a plain Identifier value
+    qasm = """
+    qubit[2] q;
+    let alias = q;
+    h alias[0];
+    """
+    circuit = Interpreter().build_circuit(qasm)
+    assert len(circuit.instructions) == 1
+    assert isinstance(circuit.instructions[0], Hadamard)
+    assert circuit.instructions[0].targets == (0,)
+
+
+def test_alias_concatenation():
+    # exercises AliasStatement with a Concatenation value
+    qasm = """
+    qubit q0;
+    qubit q1;
+    let combined = q0 ++ q1;
+    h combined[0];
+    x combined[1];
+    """
+    circuit = Interpreter().build_circuit(qasm)
+    assert len(circuit.instructions) == 2
+    assert isinstance(circuit.instructions[0], Hadamard)
+    assert circuit.instructions[0].targets == (0,)
+    assert isinstance(circuit.instructions[1], PauliX)
+    assert circuit.instructions[1].targets == (1,)
+
+
+def test_alias_unsupported_raises():
+    # exercises the NotImplementedError branch in AliasStatement
+    from braket.default_simulator.openqasm.parser.openqasm_ast import (
+        AliasStatement,
+        Identifier,
+        IntegerLiteral,
+    )
+    from braket.default_simulator.openqasm.interpreter import Interpreter as _Interp
+
+    interp = _Interp()
+    node = AliasStatement(target=Identifier("a"), value=IntegerLiteral(0))
+    with pytest.raises(NotImplementedError, match="IntegerLiteral"):
+        interp.visit(node)

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -24,7 +24,7 @@ from sympy import Symbol
 from braket.default_simulator import StateVectorSimulation
 from braket.default_simulator.openqasm.parser import openqasm_parser
 from braket.default_simulator.openqasm.interpreter import VerbatimBoxDelimiter
-from braket.default_simulator.gate_operations import CX, GPhase, Hadamard, PauliX
+from braket.default_simulator.gate_operations import CX, GPhase, Hadamard, PauliX, Reset
 from braket.default_simulator.gate_operations import PauliY as Y
 from braket.default_simulator.gate_operations import RotX, U, Unitary
 from braket.default_simulator.noise_operations import (
@@ -106,7 +106,7 @@ def test_bool_declaration():
     assert context.get_type("initialized_int") == BoolType()
     assert context.get_type("initialized_bool") == BoolType()
 
-    assert context.get_value("uninitialized") is None
+    assert context.get_value("uninitialized") == BooleanLiteral(False)
     assert context.get_value("initialized_int") == BooleanLiteral(False)
     assert context.get_value("initialized_bool") == BooleanLiteral(True)
 
@@ -135,7 +135,7 @@ def test_int_declaration():
     assert context.get_type("neg_overflow") == IntType(IntegerLiteral(3))
     assert context.get_type("no_size") == IntType(None)
 
-    assert context.get_value("uninitialized") is None
+    assert context.get_value("uninitialized") == IntegerLiteral(0)
     assert context.get_value("pos") == IntegerLiteral(10)
     assert context.get_value("neg") == IntegerLiteral(-4)
     assert context.get_value("int_min") == IntegerLiteral(-128)
@@ -172,7 +172,7 @@ def test_uint_declaration():
     assert context.get_type("neg_overflow") == UintType(IntegerLiteral(3))
     assert context.get_type("no_size") == UintType(None)
 
-    assert context.get_value("uninitialized") is None
+    assert context.get_value("uninitialized") == IntegerLiteral(0)
     assert context.get_value("pos") == IntegerLiteral(10)
     assert context.get_value("pos_not_overflow") == IntegerLiteral(5)
     assert context.get_value("pos_overflow") == IntegerLiteral(0)
@@ -224,7 +224,7 @@ def test_float_declaration():
     assert context.get_type("precise") == FloatType(IntegerLiteral(64))
     assert context.get_type("unsized") == FloatType(None)
 
-    assert context.get_value("uninitialized") is None
+    assert context.get_value("uninitialized") == FloatLiteral(0.0)
     assert context.get_value("pos") == FloatLiteral(10)
     assert context.get_value("neg") == FloatLiteral(-4.2)
     assert context.get_value("precise") == FloatLiteral(np.pi)
@@ -530,11 +530,16 @@ def test_indexed_expression():
 def test_reset_qubit():
     qasm = """
     qubit q;
+    x q;
     reset q;
     """
-    no_reset = "Reset not supported"
-    with pytest.raises(NotImplementedError, match=no_reset):
-        Interpreter().run(qasm)
+    context = Interpreter().run(qasm)
+    # Reset should add a Reset instruction to the circuit
+    instructions = context.circuit.instructions
+    # Should have an X gate followed by a Reset
+    assert len(instructions) == 2
+    assert isinstance(instructions[1], Reset)
+    assert instructions[1].targets == (0,)
 
 
 def test_for_loop():

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -97,13 +97,17 @@ measure_testdata = [
     (Measure([0], result=1),  np.array([_s2, _s2], dtype=complex), np.array([0.0, 1.0], dtype=complex)),
     # Two-qubit: |00⟩+|01⟩+|10⟩+|11⟩, measure qubit 1 → 0; only |00⟩ and |10⟩ survive
     (Measure([1], result=0),  0.5 * np.ones(4, dtype=complex),     np.array([_s2, 0, _s2, 0], dtype=complex)),
+    # Zero-norm after projection — state already in |0⟩, projecting to |1⟩ yields all zeros
+    (Measure([0], result=1),  np.array([1.0, 0.0], dtype=complex), np.array([0.0, 0.0], dtype=complex)),
 ]
 
 
 @pytest.mark.parametrize("operation, input_state, expected", measure_testdata)
 def test_measure_operation(operation, input_state, expected):
-    result = operation.apply(input_state.copy())
-    np.testing.assert_array_almost_equal(result, expected)
+    n_qubits = int(np.log2(len(input_state)))
+    state_tensor = input_state.copy().reshape([2] * n_qubits)
+    result = apply_operations(state_tensor, n_qubits, [operation])
+    np.testing.assert_array_almost_equal(result.flatten(), expected)
 
 
 reset_testdata = [
@@ -111,13 +115,17 @@ reset_testdata = [
     (np.array([1.0, 0.0], dtype=complex), np.array([1.0, 0.0], dtype=complex)),
     (np.array([0.0, 1.0], dtype=complex), np.array([1.0, 0.0], dtype=complex)),
     (np.array([_s2,  _s2], dtype=complex), np.array([1.0, 0.0], dtype=complex)),
+    # zero-norm input — should not divide by zero
+    (np.zeros(2, dtype=complex), np.zeros(2, dtype=complex)),
 ]
 
 
 @pytest.mark.parametrize("input_state, expected", reset_testdata)
 def test_reset_operation(input_state, expected):
-    result = Reset([0]).apply(input_state.copy())
-    np.testing.assert_array_almost_equal(result, expected)
+    n_qubits = int(np.log2(len(input_state)))
+    state_tensor = input_state.copy().reshape([2] * n_qubits)
+    result = apply_operations(state_tensor, n_qubits, [Reset([0])])
+    np.testing.assert_array_almost_equal(result.flatten(), expected)
 
 
 def test_measure_invalid_result_raises():
@@ -132,32 +140,3 @@ def test_measure_multi_qubit_raises():
         Measure([0, 1], result=0).apply(0.5 * np.ones(4, dtype=complex))
 
 
-def test_measure_zero_norm_state():
-    # norm == 0 after projection — should not divide by zero
-    m = Measure([0], result=1)
-    state = np.array([1.0, 0.0], dtype=complex)  # already in |0⟩, projecting to |1⟩ → zero norm
-    result = m.apply(state.copy())
-    np.testing.assert_array_almost_equal(result, [0.0, 0.0])
-
-
-def test_reset_zero_norm_state():
-    # norm == 0 after reset — should not divide by zero
-    r = Reset([0])
-    state = np.zeros(2, dtype=complex)
-    result = r.apply(state.copy())
-    np.testing.assert_array_almost_equal(result, [0.0, 0.0])
-
-
-def test_apply_operations_with_measure():
-    # exercises the Measure/Reset branch in single_operation_strategy
-    state = np.array([_s2, _s2], dtype=complex).reshape(2)
-    ops = [Measure([0], result=0)]
-    result = apply_operations(state, 1, ops)
-    np.testing.assert_array_almost_equal(result.flatten(), [1.0, 0.0])
-
-
-def test_apply_operations_with_reset():
-    state = np.array([0.0, 1.0], dtype=complex).reshape(2)
-    ops = [Reset([0])]
-    result = apply_operations(state, 1, ops)
-    np.testing.assert_array_almost_equal(result.flatten(), [1.0, 0.0])

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -18,6 +18,9 @@ import pytest
 from braket.default_simulator import gate_operations
 from braket.default_simulator.gate_operations import Measure, Reset
 from braket.default_simulator.operation_helpers import check_unitary, from_braket_instruction
+from braket.default_simulator.simulation_strategies.single_operation_strategy import (
+    apply_operations,
+)
 
 testdata = [
     (instruction.I(target=4), (4,), gate_operations.Identity),
@@ -115,3 +118,49 @@ reset_testdata = [
 def test_reset_operation(input_state, expected):
     result = Reset([0]).apply(input_state.copy())
     np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_measure_invalid_result_raises():
+    # only 0 and 1 are valid results for _base_matrix; -1 (unset) and anything else should raise
+    for bad in (-1, 99):
+        with pytest.raises(ValueError, match="Invalid measurement result"):
+            Measure([0], result=bad)._base_matrix
+
+
+def test_measure_multi_qubit_noop():
+    # len(targets) != 1 — apply returns projected_state unchanged (no single-qubit branch)
+    m = Measure([0, 1], result=0)
+    state = np.array([_s2, 0, _s2, 0], dtype=complex)
+    result = m.apply(state.copy())
+    np.testing.assert_array_almost_equal(result, state)
+
+
+def test_measure_zero_norm_state():
+    # norm == 0 after projection — should not divide by zero
+    m = Measure([0], result=1)
+    state = np.array([1.0, 0.0], dtype=complex)  # already in |0⟩, projecting to |1⟩ → zero norm
+    result = m.apply(state.copy())
+    np.testing.assert_array_almost_equal(result, [0.0, 0.0])
+
+
+def test_reset_zero_norm_state():
+    # norm == 0 after reset — should not divide by zero
+    r = Reset([0])
+    state = np.zeros(2, dtype=complex)
+    result = r.apply(state.copy())
+    np.testing.assert_array_almost_equal(result, [0.0, 0.0])
+
+
+def test_apply_operations_with_measure():
+    # exercises the Measure/Reset branch in single_operation_strategy
+    state = np.array([_s2, _s2], dtype=complex).reshape(2)
+    ops = [Measure([0], result=0)]
+    result = apply_operations(state, 1, ops)
+    np.testing.assert_array_almost_equal(result.flatten(), [1.0, 0.0])
+
+
+def test_apply_operations_with_reset():
+    state = np.array([0.0, 1.0], dtype=complex).reshape(2)
+    ops = [Reset([0])]
+    result = apply_operations(state, 1, ops)
+    np.testing.assert_array_almost_equal(result.flatten(), [1.0, 0.0])

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -127,12 +127,9 @@ def test_measure_invalid_result_raises():
             Measure([0], result=bad)._base_matrix
 
 
-def test_measure_multi_qubit_noop():
-    # len(targets) != 1 — apply returns projected_state unchanged (no single-qubit branch)
-    m = Measure([0, 1], result=0)
-    state = np.array([_s2, 0, _s2, 0], dtype=complex)
-    result = m.apply(state.copy())
-    np.testing.assert_array_almost_equal(result, state)
+def test_measure_multi_qubit_raises():
+    with pytest.raises(ValueError, match="single target qubit"):
+        Measure([0, 1], result=0).apply(0.5 * np.ones(4, dtype=complex))
 
 
 def test_measure_zero_norm_state():

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -128,16 +128,9 @@ def test_reset_operation(input_state, expected):
     np.testing.assert_array_almost_equal(result.flatten(), expected)
 
 
-def test_measure_invalid_result_raises():
-    # only 0 and 1 are valid results for _base_matrix; -1 (unset) and anything else should raise
-    for bad in (-1, 99):
-        with pytest.raises(ValueError, match="Invalid measurement result"):
-            Measure([0], result=bad)._base_matrix
-
-
-def test_measure_base_matrix():
-    np.testing.assert_array_equal(Measure([0], result=0)._base_matrix, np.array([[1, 0], [0, 0]], dtype=complex))
-    np.testing.assert_array_equal(Measure([0], result=1)._base_matrix, np.array([[0, 0], [0, 1]], dtype=complex))
+def test_measure_base_matrix_raises():
+    with pytest.raises(NotImplementedError):
+        Measure([0], result=0)._base_matrix
 
 
 def test_measure_multi_qubit_raises():

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -12,9 +12,11 @@
 # language governing permissions and limitations under the License.
 
 import braket.ir.jaqcd as instruction
+import numpy as np
 import pytest
 
 from braket.default_simulator import gate_operations
+from braket.default_simulator.gate_operations import Measure, Reset
 from braket.default_simulator.operation_helpers import check_unitary, from_braket_instruction
 
 testdata = [
@@ -81,3 +83,94 @@ def test_gate_operation(ir_instruction, targets, operation_type):
     assert isinstance(operation_instance, operation_type)
     assert operation_instance.targets == targets
     check_unitary(operation_instance.matrix)
+
+
+# ---------------------------------------------------------------------------
+# Measure class tests
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureBaseMatrix:
+    """Cover all branches of Measure._base_matrix."""
+
+    def test_identity_when_result_negative_one(self):
+        m = Measure([0], result=-1)
+        np.testing.assert_array_equal(m._base_matrix, np.eye(2))
+
+    def test_project_to_zero(self):
+        m = Measure([0], result=0)
+        expected = np.array([[1, 0], [0, 0]], dtype=complex)
+        np.testing.assert_array_equal(m._base_matrix, expected)
+
+    def test_project_to_one(self):
+        m = Measure([0], result=1)
+        expected = np.array([[0, 0], [0, 1]], dtype=complex)
+        np.testing.assert_array_equal(m._base_matrix, expected)
+
+    def test_invalid_result_returns_identity(self):
+        m = Measure([0], result=99)
+        np.testing.assert_array_equal(m._base_matrix, np.eye(2))
+
+
+class TestMeasureApply:
+    """Cover Measure.apply for single-qubit projections."""
+
+    def test_apply_no_op_when_result_unset(self):
+        m = Measure([0], result=-1)
+        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
+        result = m.apply(state.copy())
+        np.testing.assert_array_almost_equal(result, state)
+
+    def test_apply_project_to_zero(self):
+        m = Measure([0], result=0)
+        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
+        result = m.apply(state)
+        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
+
+    def test_apply_project_to_one(self):
+        m = Measure([0], result=1)
+        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
+        result = m.apply(state)
+        np.testing.assert_array_almost_equal(result, [0.0, 1.0])
+
+    def test_apply_two_qubit_project_second_to_zero(self):
+        """Two-qubit state |00⟩+|01⟩+|10⟩+|11⟩, measure qubit 1 → 0."""
+        m = Measure([1], result=0)
+        state = 0.5 * np.ones(4, dtype=complex)
+        result = m.apply(state)
+        # Only |00⟩ and |10⟩ survive
+        expected = np.array([1 / np.sqrt(2), 0, 1 / np.sqrt(2), 0], dtype=complex)
+        np.testing.assert_array_almost_equal(result, expected)
+
+
+# ---------------------------------------------------------------------------
+# Reset class tests
+# ---------------------------------------------------------------------------
+
+
+class TestResetApply:
+    """Cover Reset.apply for single-qubit resets."""
+
+    def test_reset_zero_state_unchanged(self):
+        r = Reset([0])
+        state = np.array([1.0, 0.0], dtype=complex)
+        result = r.apply(state.copy())
+        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
+
+    def test_reset_one_state_to_zero(self):
+        r = Reset([0])
+        state = np.array([0.0, 1.0], dtype=complex)
+        result = r.apply(state)
+        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
+
+    def test_reset_superposition(self):
+        r = Reset([0])
+        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
+        result = r.apply(state)
+        # Both amplitudes collapse to |0⟩
+        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
+
+    def test_reset_base_matrix_raises(self):
+        r = Reset([0])
+        with pytest.raises(NotImplementedError):
+            _ = r._base_matrix

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -135,8 +135,18 @@ def test_measure_invalid_result_raises():
             Measure([0], result=bad)._base_matrix
 
 
+def test_measure_base_matrix():
+    np.testing.assert_array_equal(Measure([0], result=0)._base_matrix, np.array([[1, 0], [0, 0]], dtype=complex))
+    np.testing.assert_array_equal(Measure([0], result=1)._base_matrix, np.array([[0, 0], [0, 1]], dtype=complex))
+
+
 def test_measure_multi_qubit_raises():
     with pytest.raises(ValueError, match="single target qubit"):
         Measure([0, 1], result=0).apply(0.5 * np.ones(4, dtype=complex))
+
+
+def test_reset_multi_qubit_raises():
+    with pytest.raises(ValueError, match="single target qubit"):
+        Reset([0, 1]).apply(0.5 * np.ones(4, dtype=complex))
 
 

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -85,92 +85,33 @@ def test_gate_operation(ir_instruction, targets, operation_type):
     check_unitary(operation_instance.matrix)
 
 
-# ---------------------------------------------------------------------------
-# Measure class tests
-# ---------------------------------------------------------------------------
+_s2 = 1 / np.sqrt(2)
+
+measure_testdata = [
+    # (operation, input_state, expected_output_state)
+    (Measure([0], result=-1), np.array([_s2, _s2], dtype=complex), np.array([_s2, _s2], dtype=complex)),
+    (Measure([0], result=0),  np.array([_s2, _s2], dtype=complex), np.array([1.0, 0.0], dtype=complex)),
+    (Measure([0], result=1),  np.array([_s2, _s2], dtype=complex), np.array([0.0, 1.0], dtype=complex)),
+    # Two-qubit: |00⟩+|01⟩+|10⟩+|11⟩, measure qubit 1 → 0; only |00⟩ and |10⟩ survive
+    (Measure([1], result=0),  0.5 * np.ones(4, dtype=complex),     np.array([_s2, 0, _s2, 0], dtype=complex)),
+]
 
 
-class TestMeasureBaseMatrix:
-    """Cover all branches of Measure._base_matrix."""
-
-    def test_identity_when_result_negative_one(self):
-        m = Measure([0], result=-1)
-        np.testing.assert_array_equal(m._base_matrix, np.eye(2))
-
-    def test_project_to_zero(self):
-        m = Measure([0], result=0)
-        expected = np.array([[1, 0], [0, 0]], dtype=complex)
-        np.testing.assert_array_equal(m._base_matrix, expected)
-
-    def test_project_to_one(self):
-        m = Measure([0], result=1)
-        expected = np.array([[0, 0], [0, 1]], dtype=complex)
-        np.testing.assert_array_equal(m._base_matrix, expected)
-
-    def test_invalid_result_returns_identity(self):
-        m = Measure([0], result=99)
-        np.testing.assert_array_equal(m._base_matrix, np.eye(2))
+@pytest.mark.parametrize("operation, input_state, expected", measure_testdata)
+def test_measure_operation(operation, input_state, expected):
+    result = operation.apply(input_state.copy())
+    np.testing.assert_array_almost_equal(result, expected)
 
 
-class TestMeasureApply:
-    """Cover Measure.apply for single-qubit projections."""
-
-    def test_apply_no_op_when_result_unset(self):
-        m = Measure([0], result=-1)
-        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
-        result = m.apply(state.copy())
-        np.testing.assert_array_almost_equal(result, state)
-
-    def test_apply_project_to_zero(self):
-        m = Measure([0], result=0)
-        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
-        result = m.apply(state)
-        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
-
-    def test_apply_project_to_one(self):
-        m = Measure([0], result=1)
-        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
-        result = m.apply(state)
-        np.testing.assert_array_almost_equal(result, [0.0, 1.0])
-
-    def test_apply_two_qubit_project_second_to_zero(self):
-        """Two-qubit state |00⟩+|01⟩+|10⟩+|11⟩, measure qubit 1 → 0."""
-        m = Measure([1], result=0)
-        state = 0.5 * np.ones(4, dtype=complex)
-        result = m.apply(state)
-        # Only |00⟩ and |10⟩ survive
-        expected = np.array([1 / np.sqrt(2), 0, 1 / np.sqrt(2), 0], dtype=complex)
-        np.testing.assert_array_almost_equal(result, expected)
+reset_testdata = [
+    # (input_state, expected_output_state)
+    (np.array([1.0, 0.0], dtype=complex), np.array([1.0, 0.0], dtype=complex)),
+    (np.array([0.0, 1.0], dtype=complex), np.array([1.0, 0.0], dtype=complex)),
+    (np.array([_s2,  _s2], dtype=complex), np.array([1.0, 0.0], dtype=complex)),
+]
 
 
-# ---------------------------------------------------------------------------
-# Reset class tests
-# ---------------------------------------------------------------------------
-
-
-class TestResetApply:
-    """Cover Reset.apply for single-qubit resets."""
-
-    def test_reset_zero_state_unchanged(self):
-        r = Reset([0])
-        state = np.array([1.0, 0.0], dtype=complex)
-        result = r.apply(state.copy())
-        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
-
-    def test_reset_one_state_to_zero(self):
-        r = Reset([0])
-        state = np.array([0.0, 1.0], dtype=complex)
-        result = r.apply(state)
-        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
-
-    def test_reset_superposition(self):
-        r = Reset([0])
-        state = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex)
-        result = r.apply(state)
-        # Both amplitudes collapse to |0⟩
-        np.testing.assert_array_almost_equal(result, [1.0, 0.0])
-
-    def test_reset_base_matrix_raises(self):
-        r = Reset([0])
-        with pytest.raises(NotImplementedError):
-            _ = r._base_matrix
+@pytest.mark.parametrize("input_state, expected", reset_testdata)
+def test_reset_operation(input_state, expected):
+    result = Reset([0]).apply(input_state.copy())
+    np.testing.assert_array_almost_equal(result, expected)


### PR DESCRIPTION
This PR lays the groundwork for mid-circuit measurement support by introducing `Measure` and `Reset` gate operations, wiring them into the simulation pipeline, and fixing several interpreter correctness issues along the way.

## Changes

### New gate operations (`gate_operations.py`)

- `Measure` — a `GateOperation` subclass that projects the state vector to a specific outcome (0 or 1) via amplitude masking and renormalization. When `result=-1` (unset), `apply` is a no-op. Both `Measure` and `Reset` raise `NotImplementedError` for `_base_matrix` since neither has a unitary matrix representation. Both raise `ValueError` if called with more than one target qubit.
- `Reset` — a `GateOperation` subclass that unconditionally resets a target qubit to |0⟩ by transferring amplitude from the |1⟩ component and renormalizing.

### Simulation strategy (`single_operation_strategy.py`)

- `Measure` and `Reset` are now handled as a special case in `apply_operations`: the state tensor is flattened to 1D, passed to `op.apply()`, then reshaped back. All other operations continue through the existing matrix contraction path.
- Added a `# TODO: support MCM` note in `batch_operation_strategy.py` to track the remaining work there.

### Interpreter fixes (`interpreter.py`)

- `QuantumReset` now calls `context.add_reset(...)` instead of raising `NotImplementedError`.
- `BranchingStatement` now visits `if_block` / `else_block` as a whole node rather than iterating over statements directly, fixing block-scoping behavior.
- `ForInLoop` and `WhileLoop` now catch `_BreakSignal` / `_ContinueSignal` to support `break` and `continue` statements.
- New visitor handlers for `BreakStatement`, `ContinueStatement`, and `AliasStatement` (including concatenation aliases via `++`).
- Uninitialized `int`, `uint`, `float`, and `bool` declarations now default to `0`, `0`, `0.0`, and `False` respectively, matching OpenQASM 3 spec behavior.
- Fixed identifier resolution in `QuantumMeasurementStatement` target handling — `Identifier` nodes are now visited before accessing `.value`.
- Added missing AST imports: `AliasStatement`, `BoolType`, `BreakStatement`, `Concatenation`, `ContinueStatement`, `FloatType`, `IntType`, `UintType`.

### Program context (`program_context.py`)

- `add_reset` stub added to `AbstractProgramContext`; `ProgramContext` implements it by appending a `Reset` instruction per target qubit.
- `_BreakSignal` and `_ContinueSignal` exception classes added as internal control-flow signals for loop handling.

### Tests

- `test_gate_operations.py` — parametrized `test_measure_operation` and `test_reset_operation` covering projection, normalization, no-op, two-qubit, and zero-norm cases; all routed through `apply_operations` to also cover the strategy dispatch branch. Additional tests for `_base_matrix` raises, and `ValueError` on multi-target inputs for both `Measure` and `Reset`.
- `test_interpreter.py` — `test_reset_qubit` updated to assert reset actually works; uninitialized variable tests updated to reflect new default-value behavior; new tests for `else` branch, `break`/`continue` in loops, and all three `AliasStatement` branches (simple, concatenation, unsupported).

## Notes

- `batch_operation_strategy` does not yet support `Measure`/`Reset` because they cannot be grouped with other gate operations — tracked with a TODO comment.
- `Measure` is intended for use in branched simulation (replaying instruction sequences with known outcomes); it is not a sampling operation.
