### PR TITLE
fix: Fix incorrect CNOT gate application for non-adjacent qubits on >10 qubit circuits

### DIFF
--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -280,57 +280,16 @@ def _apply_cnot_large(
     """CNOT optimization path with numba."""
     n_qubits = state.ndim
     total_size = state.size
-    iterations = total_size >> 2
 
-    target_bit_pos = n_qubits - target - 1
-    control_bit_pos = n_qubits - control - 1
-
-    control_stride = 1 << control_bit_pos
-    target_stride = 1 << target_bit_pos
-
-    if control_bit_pos > target_bit_pos:
-        larger_bit_pos = control_bit_pos
-        smaller_bit_pos = target_bit_pos
-
-        larger_jump = control_stride if control_bit_pos != n_qubits - 1 else 0
-        smaller_jump = target_stride if target_bit_pos != n_qubits - 1 else 0
-
-        swap_offset = target_stride
-    else:
-        larger_bit_pos = target_bit_pos
-        smaller_bit_pos = control_bit_pos
-
-        larger_jump = target_stride if target_bit_pos != n_qubits - 1 else 0
-        smaller_jump = control_stride if control_bit_pos != n_qubits - 1 else 0
-
-        swap_offset = target_stride
-
-    should_smaller_jump = smaller_jump or 1
-    should_larger_jump = larger_jump or 1
-
-    if larger_bit_pos - smaller_bit_pos >= (n_qubits - smaller_bit_pos) // 2:
-        should_larger_jump = max(should_larger_jump // 2, 1)
+    control_mask = 1 << (n_qubits - 1 - control)
+    target_mask = 1 << (n_qubits - 1 - target)
 
     state_flat = state.reshape(-1)
 
-    if larger_bit_pos - smaller_bit_pos == 1:
-        combined_jump = smaller_jump + larger_jump
-        for i in nb.prange(iterations):
-            idx0 = control_stride + i + (i // should_smaller_jump) * combined_jump
-            idx1 = idx0 + swap_offset
-
-            state_flat[idx0], state_flat[idx1] = state_flat[idx1], state_flat[idx0]
-    else:
-        for i in nb.prange(iterations):
-            idx0 = (
-                control_stride
-                + i
-                + (i // should_smaller_jump) * smaller_jump
-                + (i // should_larger_jump) * larger_jump
-            )
-            idx1 = idx0 + swap_offset
-
-            state_flat[idx0], state_flat[idx1] = state_flat[idx1], state_flat[idx0]
+    for i in nb.prange(total_size):
+        if (i & (control_mask | target_mask)) == control_mask:
+            j = i | target_mask
+            state_flat[i], state_flat[j] = state_flat[j], state_flat[i]
 
     return state, False
 


### PR DESCRIPTION
## Description

Fixes incorrect measurement outcomes from the state vector simulator when applying CNOT gates with non-adjacent control and target qubits on circuits with more than 10 qubits.

## Bug

The `_apply_cnot_large` numba-optimized function (used when qubit count > 10) had a flawed stride-based index enumeration that produced incorrect swap pairs when control and target qubits were non-adjacent (bit position gap > 1). This caused the CNOT to operate on the wrong subset of the state vector.

**Trigger conditions** (all three required):
1. Circuit has >10 qubits (triggers the `_large` numba path)
2. CNOT gate where control and target qubits are non-adjacent (e.g., `CNOT(3, 5)`)
3. Non-trivial state in the affected amplitudes

**Example**: A 4-qubit GHZ state prepared with a log-depth CNOT tree on qubits 2-5, with identity gates on qubits 0,1,6-10 (11 total), would produce `[1, 1, 1, 0]` instead of the expected `[1, 1, 1, 1]`.

## Fix

Replace the broken stride-based index enumeration with a simple bit-mask approach, matching the pattern already used correctly by `_apply_two_qubit_gate_large`:

```python
for i in nb.prange(total_size):
    if (i & (control_mask | target_mask)) == control_mask:
        j = i | target_mask
        state_flat[i], state_flat[j] = state_flat[j], state_flat[i]
```

This iterates all state vector indices, selects those where `control=1` and `target=0`, and swaps with the corresponding `target=1` index.

## Testing

- Reproduction test from the bug report passes (GHZ tree + identity qubits on 11 qubits)
- Full existing test suite passes (963 passed, 60 xfailed)

## Related

Regression introduced in #283 (v1.31.0).