### PR TITLE
fix: Fix incorrect CNOT gate application for non-adjacent qubits on >10 qubit circuits

### DIFF
--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -280,57 +280,16 @@ def _apply_cnot_large(
     """CNOT optimization path with numba."""
     n_qubits = state.ndim
     total_size = state.size
-    iterations = total_size >> 2
 
-    target_bit_pos = n_qubits - target - 1
-    control_bit_pos = n_qubits - control - 1
-
-    control_stride = 1 << control_bit_pos
-    target_stride = 1 << target_bit_pos
-
-    if control_bit_pos > target_bit_pos:
-        larger_bit_pos = control_bit_pos
-        smaller_bit_pos = target_bit_pos
-
-        larger_jump = control_stride if control_bit_pos != n_qubits - 1 else 0
-        smaller_jump = target_stride if target_bit_pos != n_qubits - 1 else 0
-
-        swap_offset = target_stride
-    else:
-        larger_bit_pos = target_bit_pos
-        smaller_bit_pos = control_bit_pos
-
-        larger_jump = target_stride if target_bit_pos != n_qubits - 1 else 0
-        smaller_jump = control_stride if control_bit_pos != n_qubits - 1 else 0
-
-        swap_offset = target_stride
-
-    should_smaller_jump = smaller_jump or 1
-    should_larger_jump = larger_jump or 1
-
-    if larger_bit_pos - smaller_bit_pos >= (n_qubits - smaller_bit_pos) // 2:
-        should_larger_jump = max(should_larger_jump // 2, 1)
+    control_mask = 1 << (n_qubits - 1 - control)
+    target_mask = 1 << (n_qubits - 1 - target)
 
     state_flat = state.reshape(-1)
 
-    if larger_bit_pos - smaller_bit_pos == 1:
-        combined_jump = smaller_jump + larger_jump
-        for i in nb.prange(iterations):
-            idx0 = control_stride + i + (i // should_smaller_jump) * combined_jump
-            idx1 = idx0 + swap_offset
-
-            state_flat[idx0], state_flat[idx1] = state_flat[idx1], state_flat[idx0]
-    else:
-        for i in nb.prange(iterations):
-            idx0 = (
-                control_stride
-                + i
-                + (i // should_smaller_jump) * smaller_jump
-                + (i // should_larger_jump) * larger_jump
-            )
-            idx1 = idx0 + swap_offset
-
-            state_flat[idx0], state_flat[idx1] = state_flat[idx1], state_flat[idx0]
+    for i in nb.prange(total_size):
+        if (i & (control_mask | target_mask)) == control_mask:
+            j = i | target_mask
+            state_flat[i], state_flat[j] = state_flat[j], state_flat[i]
 
     return state, False
 

--- a/test/unit_tests/braket/default_simulator/test_linalg_utils.py
+++ b/test/unit_tests/braket/default_simulator/test_linalg_utils.py
@@ -941,6 +941,7 @@ def test_apply_cnot_large_ghz_tree():
     h = np.array([[1, 1], [1, -1]], dtype=complex) / np.sqrt(2)
     out = np.zeros_like(state)
     from braket.default_simulator.linalg_utils import _apply_single_qubit_gate_large
+
     state, _ = _apply_single_qubit_gate_large(state, h, 2, out)
 
     # CNOT(2,3), CNOT(2,4), CNOT(3,5) — tree structure

--- a/test/unit_tests/braket/default_simulator/test_linalg_utils.py
+++ b/test/unit_tests/braket/default_simulator/test_linalg_utils.py
@@ -15,6 +15,8 @@ import numpy as np
 import pytest
 
 from braket.default_simulator.linalg_utils import (
+    _apply_cnot_large,
+    _apply_cnot_small,
     _apply_single_qubit_gate_large,
     _apply_diagonal_gate_small,
     _apply_diagonal_gate_large,
@@ -890,4 +892,71 @@ def test_apply_diagonal_gate_large_via_single_qubit_gate():
         result_norm = np.linalg.norm(result_multi.flatten())
         assert np.isclose(original_norm, result_norm, atol=1e-7), (
             f"Norm not preserved for target {target_qubit}"
+        )
+
+
+@pytest.mark.parametrize(
+    "control, target, qubit_count",
+    [
+        (0, 1, 3),
+        (1, 0, 3),
+        (0, 2, 3),
+        (2, 0, 3),
+        (0, 2, 4),
+        (1, 3, 4),
+        (3, 5, 11),
+        (2, 4, 11),
+        (0, 10, 11),
+        (10, 0, 11),
+    ],
+)
+def test_apply_cnot_large_matches_small(control, target, qubit_count):
+    """Test that _apply_cnot_large produces the same result as _apply_cnot_small."""
+    np.random.seed(42)
+    state_flat = np.random.random(2**qubit_count) + 1j * np.random.random(2**qubit_count)
+    state_flat = state_flat / np.linalg.norm(state_flat)
+
+    state_small = state_flat.reshape([2] * qubit_count).copy()
+    state_large = state_flat.reshape([2] * qubit_count).copy()
+    out = np.zeros_like(state_small)
+
+    result_small, _ = _apply_cnot_small(state_small, control, target, out)
+    result_large, _ = _apply_cnot_large(state_large, control, target, out)
+
+    assert np.allclose(result_small, result_large, atol=1e-7), (
+        f"CNOT({control},{target}) on {qubit_count} qubits: small and large paths differ"
+    )
+
+
+def test_apply_cnot_large_ghz_tree():
+    """Test CNOT large path with log-depth GHZ tree on >10 qubits.
+
+    Regression test for non-adjacent CNOT producing incorrect state vectors.
+    """
+    n_qubits = 11
+    state = np.zeros([2] * n_qubits, dtype=complex)
+    state[tuple([0] * n_qubits)] = 1.0
+
+    # H on qubit 2
+    h = np.array([[1, 1], [1, -1]], dtype=complex) / np.sqrt(2)
+    out = np.zeros_like(state)
+    from braket.default_simulator.linalg_utils import _apply_single_qubit_gate_large
+    state, _ = _apply_single_qubit_gate_large(state, h, 2, out)
+
+    # CNOT(2,3), CNOT(2,4), CNOT(3,5) — tree structure
+    for ctrl, tgt in [(2, 3), (2, 4), (3, 5)]:
+        out = np.zeros_like(state)
+        state, _ = _apply_cnot_large(state, ctrl, tgt, out)
+
+    flat = state.reshape(-1)
+    probs = np.abs(flat) ** 2
+    nonzero = np.where(probs > 1e-10)[0]
+
+    # Should have exactly 2 nonzero amplitudes: |00000000000> and |00111100000>
+    assert len(nonzero) == 2
+    for idx in nonzero:
+        bits = format(idx, f"0{n_qubits}b")
+        ghz_bits = [int(bits[i]) for i in [2, 3, 4, 5]]
+        assert all(b == 0 for b in ghz_bits) or all(b == 1 for b in ghz_bits), (
+            f"GHZ qubits {ghz_bits} are not all-0 or all-1 for state |{bits}>"
         )

--- a/test/unit_tests/braket/default_simulator/test_state_vector_simulation.py
+++ b/test/unit_tests/braket/default_simulator/test_state_vector_simulation.py
@@ -473,3 +473,74 @@ def test_instantiation_fails_batch_size_wrong_type(batch_size):
 @pytest.mark.xfail(raises=ValueError)
 def test_instantiation_fails_batch_size_nonpositive(batch_size):
     StateVectorSimulation(4, 0, batch_size)
+
+
+_ghz_tree_ops_12q = [gate_operations.Identity([q]) for q in [0, 1, 6, 7, 8, 9, 10, 11]] + [
+    gate_operations.Hadamard([2]),
+    gate_operations.CX([2, 3]),
+    gate_operations.CX([2, 4]),
+    gate_operations.CX([3, 5]),
+]
+
+_ghz_linear_ops_12q = [gate_operations.Identity([q]) for q in [0, 1, 6, 7, 8, 9, 10, 11]] + [
+    gate_operations.Hadamard([2]),
+    gate_operations.CX([2, 3]),
+    gate_operations.CX([3, 4]),
+    gate_operations.CX([4, 5]),
+]
+
+_ghz_tree_ops_6q = [
+    gate_operations.Hadamard([2]),
+    gate_operations.CX([2, 3]),
+    gate_operations.CX([2, 4]),
+    gate_operations.CX([3, 5]),
+]
+
+
+def _expected_ghz_probabilities(qubit_count):
+    probs = np.zeros(2**qubit_count)
+    probs[0] = 0.5
+    idx = sum(1 << (qubit_count - 1 - q) for q in [2, 3, 4, 5])
+    probs[idx] = 0.5
+    return probs
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, 10])
+def test_ghz_tree_with_identity_qubits(batch_size):
+    simulation = StateVectorSimulation(12, 0, batch_size)
+    simulation.evolve(_ghz_tree_ops_12q)
+    assert np.allclose(simulation.probabilities, _expected_ghz_probabilities(12))
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, 10])
+def test_ghz_linear_with_identity_qubits(batch_size):
+    simulation = StateVectorSimulation(12, 0, batch_size)
+    simulation.evolve(_ghz_linear_ops_12q)
+    assert np.allclose(simulation.probabilities, _expected_ghz_probabilities(12))
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, 10])
+def test_ghz_tree_without_identity_qubits(batch_size):
+    simulation = StateVectorSimulation(6, 0, batch_size)
+    simulation.evolve(_ghz_tree_ops_6q)
+    assert np.allclose(simulation.probabilities, _expected_ghz_probabilities(6))
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, 10])
+def test_ghz_tree_matches_linear(batch_size):
+    sim_tree = StateVectorSimulation(12, 0, batch_size)
+    sim_tree.evolve(_ghz_tree_ops_12q)
+    sim_linear = StateVectorSimulation(12, 0, batch_size)
+    sim_linear.evolve(_ghz_linear_ops_12q)
+    assert np.allclose(sim_tree.state_vector, sim_linear.state_vector)
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, 10])
+def test_ghz_tree_retrieve_samples(batch_size):
+    simulation = StateVectorSimulation(12, 10000, batch_size)
+    simulation.evolve(_ghz_tree_ops_12q)
+    counter = Counter(simulation.retrieve_samples())
+    assert counter.keys() == {0, 960}
+    assert 0.4 < counter[0] / (counter[0] + counter[960]) < 0.6
+    assert 0.4 < counter[960] / (counter[0] + counter[960]) < 0.6
+    assert counter[0] + counter[960] == 10000


### PR DESCRIPTION
## Description

Fixes incorrect measurement outcomes from the state vector simulator when applying CNOT gates with non-adjacent control and target qubits on circuits with more than 10 qubits.

## Bug

The `_apply_cnot_large` numba-optimized function (used when qubit count > 10) had a flawed stride-based index enumeration that produced incorrect swap pairs when control and target qubits were non-adjacent (bit position gap > 1). This caused the CNOT to operate on the wrong subset of the state vector.

**Trigger conditions** (all three required):
1. Circuit has >10 qubits (triggers the `_large` numba path)
2. CNOT gate where control and target qubits are non-adjacent (e.g., `CNOT(3, 5)`)
3. Non-trivial state in the affected amplitudes

**Example**: A 4-qubit GHZ state prepared with a log-depth CNOT tree on qubits 2-5, with identity gates on qubits 0,1,6-10 (11 total), would produce `[1, 1, 1, 0]` instead of the expected `[1, 1, 1, 1]`.

## Fix

Replace the broken stride-based index enumeration with a simple bit-mask approach, matching the pattern already used correctly by `_apply_two_qubit_gate_large`:

```python
for i in nb.prange(total_size):
    if (i & (control_mask | target_mask)) == control_mask:
        j = i | target_mask
        state_flat[i], state_flat[j] = state_flat[j], state_flat[i]
```

This iterates all state vector indices, selects those where `control=1` and `target=0`, and swaps with the corresponding `target=1` index.

## Testing

- Reproduction test from the bug report passes (GHZ tree + identity qubits on 11 qubits)
- Full existing test suite passes (963 passed, 60 xfailed)

## Related

Regression introduced in #283 (v1.31.0).