### PR TITLE
fix: strip verbatim box in DensityMatrixSimulator to allow noise pragmas

### DIFF
--- a/src/braket/default_simulator/density_matrix_simulator.py
+++ b/src/braket/default_simulator/density_matrix_simulator.py
@@ -19,10 +19,49 @@ from braket.device_schema.simulators import (
     GateModelSimulatorDeviceCapabilities,
     GateModelSimulatorDeviceParameters,
 )
+from braket.ir.openqasm import Program as OpenQASMProgram
 
 
 class DensityMatrixSimulator(BaseLocalSimulator):
     DEVICE_ID = "braket_dm"
+
+    @staticmethod
+    def _remove_verbatim_box(source: str) -> str:
+        """Remove verbatim box wrappers while preserving the contents inside.
+        Uses brace counting to correctly handle nested braces within the box."""
+        result = []
+        lines = source.split("\n")
+        i = 0
+        while i < len(lines):
+            if (
+                lines[i].strip() == "#pragma braket verbatim"
+                and i + 1 < len(lines)
+                and "box" in lines[i + 1]
+            ):
+                # Skip pragma line and box{ line
+                i += 2
+                depth = 1
+                while i < len(lines) and depth > 0:
+                    for ch in lines[i]:
+                        if ch == "{":
+                            depth += 1
+                        elif ch == "}":
+                            depth -= 1
+                    if depth > 0:
+                        result.append(lines[i])
+                    i += 1
+            else:
+                result.append(lines[i])
+                i += 1
+        return "\n".join(result)
+
+    def run_openqasm(self, openqasm_ir, shots=0, *, batch_size=1):
+        if "#pragma braket verbatim" in openqasm_ir.source:
+            openqasm_ir = OpenQASMProgram.construct(
+                source=self._remove_verbatim_box(openqasm_ir.source),
+                inputs=openqasm_ir.inputs,
+            )
+        return super().run_openqasm(openqasm_ir, shots, batch_size=batch_size)
 
     def initialize_simulation(self, **kwargs) -> DensityMatrixSimulation:
         """

--- a/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
@@ -1008,24 +1008,28 @@ def test_verbatim_box_with_noise(simulator):
 
 
 def test_multiple_verbatim_boxes_with_noise(simulator):
-    """Test that multiple verbatim boxes with noise pragmas run successfully."""
-    source = "\n".join([
-        "OPENQASM 3.0;",
-        "bit[2] b;",
-        "#pragma braket verbatim",
-        "box{",
-        "h $0;",
-        "#pragma braket noise depolarizing(0.01) $0",
-        "}",
-        "#pragma braket verbatim",
-        "box{",
-        "cnot $0, $1;",
-        "#pragma braket noise depolarizing(0.01) $0",
-        "#pragma braket noise depolarizing(0.01) $1",
-        "}",
-        "b[0] = measure $0;",
-        "b[1] = measure $1;",
-    ])
+    """Test that multiple verbatim boxes with noise pragmas run successfully,
+    using user-written OpenQASM with whitespace variations."""
+    source = (
+        "OPENQASM 3.0;\n"
+        "bit[2] b;\n"
+        "#pragma braket verbatim\n"
+        "box {\n"
+        "  h $0;\n"
+        "  #pragma braket noise depolarizing(0.01) $0\n"
+        "}\n"
+        "#pragma braket verbatim\n"
+        "box {\n"
+        "  cnot $0, $1;\n"
+        "  #pragma braket noise depolarizing(0.01) $0\n"
+        "  #pragma braket noise depolarizing(0.01) $1\n"
+        "}\n"
+        "b[0] = measure $0;\n"
+        "b[1] = measure $1;"
+    )
+    result = simulator.run(OpenQASMProgram(source=source, inputs={}), shots=100)
+    assert len(result.measurements) == 100
+    assert result.measuredQubits == [0, 1]
     result = simulator.run(OpenQASMProgram(source=source, inputs={}), shots=100)
     assert len(result.measurements) == 100
     assert result.measuredQubits == [0, 1]
@@ -1045,3 +1049,22 @@ def test_noise_without_verbatim_box(simulator):
     result = simulator.run(OpenQASMProgram(source=source, inputs={}), shots=100)
     assert len(result.measurements) == 100
     assert result.measuredQubits == [0, 1]
+
+
+def test_remove_verbatim_box_with_nested_braces():
+    """Test that _remove_verbatim_box correctly handles nested braces."""
+    source = "\n".join([
+        "OPENQASM 3.0;",
+        "#pragma braket verbatim",
+        "box{",
+        "if (b == 1) {",
+        "x $0;",
+        "}",
+        "}",
+        "b[0] = measure $0;",
+    ])
+    result = DensityMatrixSimulator._remove_verbatim_box(source)
+    assert "#pragma braket verbatim" not in result
+    assert "box{" not in result
+    assert "if (b == 1) {" in result
+    assert "x $0;" in result

--- a/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
@@ -983,3 +983,65 @@ def test_run_program_set_dm(mock_uuid):
     assert result.programResults[0].executableResults[0] == expected_program_0_executable_results
     assert result.programResults[1].executableResults[0] == expected_program_1_executable_results
     assert result.taskMetadata == expected_metadata
+
+
+def test_verbatim_box_with_noise(simulator):
+    """Test that a verbatim circuit with noise pragmas inside the box runs successfully.
+    Without the fix, this raises QASM3ParsingError: pragmas must be global."""
+    source = "\n".join([
+        "OPENQASM 3.0;",
+        "bit[2] b;",
+        "#pragma braket verbatim",
+        "box{",
+        "h $0;",
+        "#pragma braket noise depolarizing(0.01) $0",
+        "cnot $0, $1;",
+        "#pragma braket noise depolarizing(0.01) $0",
+        "#pragma braket noise depolarizing(0.01) $1",
+        "}",
+        "b[0] = measure $0;",
+        "b[1] = measure $1;",
+    ])
+    result = simulator.run(OpenQASMProgram(source=source, inputs={}), shots=100)
+    assert len(result.measurements) == 100
+    assert result.measuredQubits == [0, 1]
+
+
+def test_multiple_verbatim_boxes_with_noise(simulator):
+    """Test that multiple verbatim boxes with noise pragmas run successfully."""
+    source = "\n".join([
+        "OPENQASM 3.0;",
+        "bit[2] b;",
+        "#pragma braket verbatim",
+        "box{",
+        "h $0;",
+        "#pragma braket noise depolarizing(0.01) $0",
+        "}",
+        "#pragma braket verbatim",
+        "box{",
+        "cnot $0, $1;",
+        "#pragma braket noise depolarizing(0.01) $0",
+        "#pragma braket noise depolarizing(0.01) $1",
+        "}",
+        "b[0] = measure $0;",
+        "b[1] = measure $1;",
+    ])
+    result = simulator.run(OpenQASMProgram(source=source, inputs={}), shots=100)
+    assert len(result.measurements) == 100
+    assert result.measuredQubits == [0, 1]
+
+
+def test_noise_without_verbatim_box(simulator):
+    """Test that a noisy circuit without verbatim box still works through run_openqasm."""
+    source = "\n".join([
+        "OPENQASM 3.0;",
+        "bit[2] b;",
+        "h $0;",
+        "#pragma braket noise depolarizing(0.01) $0",
+        "cnot $0, $1;",
+        "b[0] = measure $0;",
+        "b[1] = measure $1;",
+    ])
+    result = simulator.run(OpenQASMProgram(source=source, inputs={}), shots=100)
+    assert len(result.measurements) == 100
+    assert result.measuredQubits == [0, 1]


### PR DESCRIPTION
*Issue #, if available:*
The OpenQASM parser rejects noise pragmas inside a verbatim box because pragmas must be at global scope. When apply_gate_noise() is used on a verbatim circuit, the SDK serializes noise pragmas inside the box{} block, causing a QASM3ParsingError.

*Description of changes:*
This fix overrides run_openqasm in DensityMatrixSimulator to strip the verbatim box wrapper from the OpenQASM source before parsing, while preserving all contents (gates and noise pragmas) inside.

*Testing done:*
Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
