### PR TITLE
feat: Add `continue` and `break` handlers to program context

### DIFF
--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -625,9 +625,11 @@ class Interpreter:
                 try:
                     self.visit(deepcopy(node.block))
                 except _BreakSignal:
+                    self.context.handle_loop_break()
                     gen.close()
                     break
                 except _ContinueSignal:
+                    self.context.handle_loop_continue()
                     continue
         else:
             index = self.visit(node.set_declaration)
@@ -643,8 +645,10 @@ class Interpreter:
                     try:
                         self.visit(deepcopy(node.block))
                     except _BreakSignal:
+                        self.context.handle_loop_break()
                         break
                     except _ContinueSignal:
+                        self.context.handle_loop_continue()
                         continue
 
     @visit.register
@@ -656,17 +660,21 @@ class Interpreter:
                 try:
                     self.visit(deepcopy(node.block))
                 except _BreakSignal:
+                    self.context.handle_loop_break()
                     gen.close()
                     break
                 except _ContinueSignal:
+                    self.context.handle_loop_continue()
                     continue
         else:
             while cast_to(BooleanLiteral, self.visit(node.while_condition)).value:
                 try:
                     self.visit(deepcopy(node.block))
                 except _BreakSignal:
+                    self.context.handle_loop_break()
                     break
                 except _ContinueSignal:
+                    self.context.handle_loop_continue()
                     continue
 
     @visit.register

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -965,6 +965,20 @@ class AbstractProgramContext(ABC):
         """
         raise NotImplementedError
 
+    def handle_loop_continue(self):
+        """Called by the interpreter when a continue statement is encountered in a loop body.
+
+        Default behavior: no-op (continue to next iteration naturally).
+        Override to raise NotImplementedError if continue is not supported.
+        """
+
+    def handle_loop_break(self):
+        """Called by the interpreter when a break statement is encountered in a loop body.
+
+        Default behavior: no-op (break out of the loop naturally).
+        Override to raise NotImplementedError if break is not supported.
+        """
+
 
 class _BreakSignal(Exception):
     """Internal signal raised when a BreakStatement is encountered during branched execution."""


### PR DESCRIPTION
Add a handle_loop_continue() method to AbstractProgramContext that the interpreter calls when a continue statement is encountered in a loop body. Default is a no-op, allowing contexts to override and raise if continue is not supported (e.g., Qiskit provider's ForLoopOp/WhileLoopOp).

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
