### PR TITLE
fix: use tracking-based is_mcm_dependent in AbstractProgramContext

### DIFF
--- a/.github/scripts/update_dependency.py
+++ b/.github/scripts/update_dependency.py
@@ -25,10 +25,15 @@ from pathlib import Path
 package = "amazon-braket-default-simulator"
 path = Path.cwd().parent.resolve()
 
-for line in fileinput.input("setup.py", inplace=True):
-    # Update the amazon-braket-default-simulator dependency in setup.py to use the local path. This
-    # would help catch conflicts during the installation process.
-    replaced_line = (
-        line if package not in line else f'"{package} @ file://{path}/{package}-python",\n'
-    )
-    print(replaced_line, end="")
+# Different files use different syntax for declaring dependencies.
+dependency_files = {
+    "setup.py": f'"{package} @ file://{path}/{package}-python",\n',
+    "requirements.txt": f"{package} @ file://{path}/{package}-python\n",
+}
+
+for dep_file, replacement in dependency_files.items():
+    if not Path(dep_file).exists():
+        continue
+    for line in fileinput.input(dep_file, inplace=True):
+        replaced_line = line if package not in line else replacement
+        print(replaced_line, end="")

--- a/.github/workflows/additional-pr-checks.yml
+++ b/.github/workflows/additional-pr-checks.yml
@@ -15,6 +15,7 @@ jobs:
         dependent:
           - amazon-braket-sdk-python
           - amazon-braket-pennylane-plugin-python
+          - qiskit-braket-provider
 
     steps:
       - uses: actions/checkout@v6
@@ -32,10 +33,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install --upgrade git+https://github.com/aws/amazon-braket-schemas-python@main
+          pip install --upgrade git+https://github.com/amazon-braket/amazon-braket-schemas-python@main
           pip install -e .
           cd ..
-          git clone https://github.com/aws/${{ matrix.dependent }}.git
+          git clone https://github.com/amazon-braket/${{ matrix.dependent }}.git
           cd ${{ matrix.dependent }}
           # Update the amazon-braket-default-simulator dependency to reference the current commit
           python ${GITHUB_WORKSPACE}/.github/scripts/update_dependency.py

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -917,18 +917,25 @@ class AbstractProgramContext(ABC):
     def is_mcm_dependent(self, expression) -> bool:
         """Whether an expression depends on any mid-circuit measurement result.
 
-        An expression is MCM-dependent when any identifier it references
-        resolves (via lexical scoping) to a variable that was produced by
-        a mid-circuit measurement. Subclasses populate
-        ``_mcm_dependent_scopes`` (typically via ``track_mcm_dependency``
-        or when a measurement is recorded) so this check walks each
-        referenced identifier's scope stack and stops at the scope where
-        the name is declared.
+        The default returns ``True`` so that any subclass overriding
+        ``supports_midcircuit_measurement = True`` routes control flow
+        and classical operations through its MCM-aware handlers
+        (``evaluate_condition``, ``evaluate_for_range``,
+        ``evaluate_while_condition``, ``iter_classical_scopes``). This
+        matches the pre-tracking semantics where any MCM-capable context
+        handled every occurrence.
 
-        Used by the Interpreter to decide whether control flow and
-        classical assignments need per-path evaluation. Expressions that
-        are not MCM-dependent are evaluated once and eagerly, matching
-        non-MCM behavior.
+        Subclasses that implement MCM dependency tracking (by populating
+        ``_mcm_dependent_scopes`` via ``track_mcm_dependency`` and on
+        measurement) should override this to return a real check, e.g.::
+
+            return any(
+                self._is_name_mcm_dependent(name)
+                for name in self._referenced_identifiers(expression)
+            )
+
+        Doing so skips per-path evaluation for expressions that provably
+        do not depend on any MCM result.
 
         Args:
             expression: The AST expression to check.
@@ -936,9 +943,7 @@ class AbstractProgramContext(ABC):
         Returns:
             bool: True if the expression depends on an MCM result.
         """
-        return any(
-            self._is_name_mcm_dependent(name) for name in self._referenced_identifiers(expression)
-        )
+        return True
 
     def _is_name_mcm_dependent(self, name: str) -> bool:
         """Whether ``name`` resolves to an MCM-dependent variable.
@@ -1082,6 +1087,10 @@ class AbstractProgramContext(ABC):
         which the expression should be independently evaluated (e.g.,
         once per active simulation path).
 
+        The default yields once, matching non-branched behavior (the
+        expression is evaluated a single time). Subclasses that track
+        per-path state should override to yield once per active path.
+
         Args:
             expression: The AST expression being evaluated. Subclasses
                 may use it to flush pending side effects (e.g., mid-circuit
@@ -1090,7 +1099,7 @@ class AbstractProgramContext(ABC):
         Yields:
             None: Signals the Interpreter to evaluate the expression once.
         """
-        raise NotImplementedError
+        yield
 
     def handle_loop_continue(self):
         """Called by the interpreter when a continue statement is encountered in a loop body.
@@ -1498,6 +1507,17 @@ class ProgramContext(AbstractProgramContext):
                 self._measure_and_branch(mcm_target)
                 self._update_classical_from_measurement(mcm_target, mcm_dest)
             self._pending_mcm_targets.clear()
+
+    def is_mcm_dependent(self, expression) -> bool:
+        """Return True iff any identifier referenced in ``expression``
+        resolves (via lexical scoping) to a variable flagged as
+        MCM-dependent in ``_mcm_dependent_scopes``. Enables the
+        Interpreter to skip per-path evaluation for expressions that
+        provably do not depend on any mid-circuit measurement result.
+        """
+        return any(
+            self._is_name_mcm_dependent(name) for name in self._referenced_identifiers(expression)
+        )
 
     def track_mcm_dependency(self, lvalue_name: str, rvalue) -> None:
         """Extend the base implementation with branched-subset detection.

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -919,25 +919,18 @@ class AbstractProgramContext(ABC):
     def is_mcm_dependent(self, expression) -> bool:
         """Whether an expression depends on any mid-circuit measurement result.
 
-        The default returns ``True`` so that any subclass overriding
-        ``supports_midcircuit_measurement = True`` routes control flow
-        and classical operations through its MCM-aware handlers
-        (``evaluate_condition``, ``evaluate_for_range``,
-        ``evaluate_while_condition``, ``iter_classical_scopes``). This
-        matches the pre-tracking semantics where any MCM-capable context
-        handled every occurrence.
+        An expression is MCM-dependent when any identifier it references
+        resolves (via lexical scoping) to a variable that was produced by
+        a mid-circuit measurement. Subclasses populate
+        ``_mcm_dependent_scopes`` (typically via ``track_mcm_dependency``
+        or when a measurement is recorded) so this check walks each
+        referenced identifier's scope stack and stops at the scope where
+        the name is declared.
 
-        Subclasses that implement MCM dependency tracking (by populating
-        ``_mcm_dependent_scopes`` via ``track_mcm_dependency`` and on
-        measurement) should override this to return a real check, e.g.::
-
-            return any(
-                self._is_name_mcm_dependent(name)
-                for name in self._referenced_identifiers(expression)
-            )
-
-        Doing so skips per-path evaluation for expressions that provably
-        do not depend on any MCM result.
+        Used by the Interpreter to decide whether control flow and
+        classical assignments need per-path evaluation. Expressions that
+        are not MCM-dependent are evaluated once and eagerly, matching
+        non-MCM behavior.
 
         Args:
             expression: The AST expression to check.
@@ -945,7 +938,9 @@ class AbstractProgramContext(ABC):
         Returns:
             bool: True if the expression depends on an MCM result.
         """
-        return True
+        return any(
+            self._is_name_mcm_dependent(name) for name in self._referenced_identifiers(expression)
+        )
 
     def _is_name_mcm_dependent(self, name: str) -> bool:
         """Whether ``name`` resolves to an MCM-dependent variable.
@@ -1088,10 +1083,6 @@ class AbstractProgramContext(ABC):
         Implementations are generators that yield once for each scope in
         which the expression should be independently evaluated (e.g.,
         once per active simulation path).
-
-        The default yields once, matching non-branched behavior (the
-        expression is evaluated a single time). Subclasses that track
-        per-path state should override to yield once per active path.
 
         Args:
             expression: The AST expression being evaluated. Subclasses
@@ -1559,17 +1550,6 @@ class ProgramContext(AbstractProgramContext):
                 self._measure_and_branch(mcm_target)
                 self._update_classical_from_measurement(mcm_target, mcm_dest)
             self._pending_mcm_targets.clear()
-
-    def is_mcm_dependent(self, expression) -> bool:
-        """Return True iff any identifier referenced in ``expression``
-        resolves (via lexical scoping) to a variable flagged as
-        MCM-dependent in ``_mcm_dependent_scopes``. Enables the
-        Interpreter to skip per-path evaluation for expressions that
-        provably do not depend on any mid-circuit measurement result.
-        """
-        return any(
-            self._is_name_mcm_dependent(name) for name in self._referenced_identifiers(expression)
-        )
 
     def track_mcm_dependency(self, lvalue_name: str, rvalue) -> None:
         """Extend the base implementation with branched-subset detection.

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3749,6 +3749,12 @@ class TestAbstractContextControlFlow:
     def test_active_paths_returns_empty(self):
         assert SimpleProgramContext().active_paths == []
 
+    def test_is_mcm_dependent_defaults_to_true(self):
+        assert SimpleProgramContext().is_mcm_dependent(BooleanLiteral(True)) is True
+
+    def test_iter_classical_scopes_yields_once(self):
+        assert list(SimpleProgramContext().iter_classical_scopes(BooleanLiteral(True))) == [None]
+
 
 class TestNonMCMInterpreterControlFlow:
     """Verify the Interpreter's generic eager-evaluation paths using SimpleProgramContext.

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3749,8 +3749,9 @@ class TestAbstractContextControlFlow:
     def test_active_paths_returns_empty(self):
         assert SimpleProgramContext().active_paths == []
 
-    def test_is_mcm_dependent_defaults_to_true(self):
-        assert SimpleProgramContext().is_mcm_dependent(BooleanLiteral(True)) is True
+    def test_is_mcm_dependent_defaults_to_false_for_non_mcm_context(self):
+        # No measurements tracked → not MCM-dependent.
+        assert SimpleProgramContext().is_mcm_dependent(BooleanLiteral(True)) is False
 
     def test_iter_classical_scopes_yields_once(self):
         assert list(SimpleProgramContext().iter_classical_scopes(BooleanLiteral(True))) == [None]


### PR DESCRIPTION
*Issue #, if available:*
  
*Description of changes:*
  
`AbstractProgramContext.is_mcm_dependent` now uses the scope-tracking machinery that already exists on the base class (`_mcm_dependent_scopes`, `_is_name_mcm_dependent`, `_referenced_identifiers`). The identical override on `ProgramContext` is removed.
  
Subclasses that use a different tracking model (e.g.`qiskit-braket-provider`'s `_QiskitProgramContext`, which tracks measured bits in its own set) should override `is_mcm_dependent` to reflect that model. A companion change in `qiskit-braket-provider` does exactly this.
  
  *Testing done:*
  
  - All existing unit tests pass.
  - Updated `test_is_mcm_dependent_defaults_to_*` to reflect the new semantics (no measurements tracked → not MCM-dependent).
  - Verified the pending `qiskit-braket-provider` changes in https://github.com/amazon-braket/qiskit-braket-provider/pull/323 pass on their own against the released default simulator, as well as against this branch.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
