### PR TITLE
fix: Implementation-independent MCM check

### DIFF
--- a/.github/scripts/update_dependency.py
+++ b/.github/scripts/update_dependency.py
@@ -25,10 +25,15 @@ from pathlib import Path
 package = "amazon-braket-default-simulator"
 path = Path.cwd().parent.resolve()
 
-for line in fileinput.input("setup.py", inplace=True):
-    # Update the amazon-braket-default-simulator dependency in setup.py to use the local path. This
-    # would help catch conflicts during the installation process.
-    replaced_line = (
-        line if package not in line else f'"{package} @ file://{path}/{package}-python",\n'
-    )
-    print(replaced_line, end="")
+# Different files use different syntax for declaring dependencies.
+dependency_files = {
+    "setup.py": f'"{package} @ file://{path}/{package}-python",\n',
+    "requirements.txt": f"{package} @ file://{path}/{package}-python\n",
+}
+
+for dep_file, replacement in dependency_files.items():
+    if not Path(dep_file).exists():
+        continue
+    for line in fileinput.input(dep_file, inplace=True):
+        replaced_line = line if package not in line else replacement
+        print(replaced_line, end="")

--- a/.github/workflows/additional-pr-checks.yml
+++ b/.github/workflows/additional-pr-checks.yml
@@ -15,6 +15,7 @@ jobs:
         dependent:
           - amazon-braket-sdk-python
           - amazon-braket-pennylane-plugin-python
+          - qiskit-braket-provider
 
     steps:
       - uses: actions/checkout@v6
@@ -32,10 +33,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install --upgrade git+https://github.com/aws/amazon-braket-schemas-python@main
+          pip install --upgrade git+https://github.com/amazon-braket/amazon-braket-schemas-python@main
           pip install -e .
           cd ..
-          git clone https://github.com/aws/${{ matrix.dependent }}.git
+          git clone https://github.com/amazon-braket/${{ matrix.dependent }}.git
           cd ${{ matrix.dependent }}
           # Update the amazon-braket-default-simulator dependency to reference the current commit
           python ${GITHUB_WORKSPACE}/.github/scripts/update_dependency.py

--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -247,13 +247,11 @@ class Interpreter:
         if node.io_identifier == IOKeyword.output:
             raise NotImplementedError("Output not supported")
         else:  # IOKeyword.input:
-            if node.identifier.name not in self.context.inputs:
-                # previously raised a NameError
-                init_value = wrap_value_into_literal(Symbol(node.identifier.name))
-                node_type = SymbolLiteral
-            else:
-                init_value = wrap_value_into_literal(self.context.inputs[node.identifier.name])
-                node_type = node.type
+            init_value, node_type = (
+                (wrap_value_into_literal(self.context.inputs[node.identifier.name]), node.type)
+                if node.identifier.name in self.context.inputs
+                else (wrap_value_into_literal(Symbol(node.identifier.name)), SymbolLiteral)
+            )
             declaration = ClassicalDeclaration(node_type, node.identifier, init_value)
             self.visit(declaration)
 
@@ -599,11 +597,15 @@ class Interpreter:
         lvalue_name = get_identifier_name(node.lvalue)
         if self.context.get_const(lvalue_name):
             raise TypeError(f"Cannot update const value {lvalue_name}")
-        if node.op == getattr(AssignmentOperator, "="):
-            rvalue = self.visit(node.rvalue)
-        else:
-            op = get_operator_of_assignment_operator(node.op)
-            rvalue = self.visit(BinaryExpression(op, node.lvalue, node.rvalue))
+        rvalue = (
+            self.visit(node.rvalue)
+            if node.op == getattr(AssignmentOperator, "=")
+            else self.visit(
+                BinaryExpression(
+                    get_operator_of_assignment_operator(node.op), node.lvalue, node.rvalue
+                )
+            )
+        )
         lvalue = node.lvalue
         if isinstance(lvalue, IndexedIdentifier):
             lvalue.indices = self.visit(lvalue.indices)
@@ -663,10 +665,11 @@ class Interpreter:
                     continue
         else:
             index = self.visit(node.set_declaration)
-            if isinstance(index, RangeDefinition):
-                index_values = [IntegerLiteral(x) for x in convert_range_def_to_range(index)]
-            else:
-                index_values = index.values
+            index_values = (
+                [IntegerLiteral(x) for x in convert_range_def_to_range(index)]
+                if isinstance(index, RangeDefinition)
+                else index.values
+            )
 
             loop_var_name = node.identifier.name
             for i in index_values:

--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -597,8 +597,8 @@ class Interpreter:
         lvalue_name = get_identifier_name(node.lvalue)
         if self.context.get_const(lvalue_name):
             raise TypeError(f"Cannot update const value {lvalue_name}")
-        rvalue = (
-            self.visit(node.rvalue)
+        rvalue = self.visit(
+            node.rvalue
             if node.op == getattr(AssignmentOperator, "=")
             else self.visit(
                 BinaryExpression(

--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -581,6 +581,7 @@ class Interpreter:
             )
         if node.target and self.context.supports_midcircuit_measurement:
             self.context.add_measure(qubits, targets, classical_destination=node.target)
+            self.context.mark_mcm_dependent(get_identifier_name(node.target))
         else:
             self.context.add_measure(qubits, targets)
 

--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -609,9 +609,7 @@ class Interpreter:
         lvalue = node.lvalue
         if isinstance(lvalue, IndexedIdentifier):
             lvalue.indices = self.visit(lvalue.indices)
-        elif isinstance(rvalue, SymbolLiteral):
-            pass
-        else:
+        elif not isinstance(rvalue, SymbolLiteral):
             rvalue = cast_to(self.context.get_type(lvalue.name), rvalue)
         self.context.update_value(lvalue, rvalue)
         self.context.track_mcm_dependency(lvalue_name, node.rvalue)

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -978,6 +978,14 @@ class AbstractProgramContext(ABC):
         else:
             mcm_scope.discard(lvalue_name)
 
+    def mark_mcm_dependent(self, name: str) -> None:
+        """Unconditionally mark ``name`` as MCM-dependent in its declaration scope.
+
+        Called by the Interpreter when a variable is assigned a value that
+        is inherently MCM-dependent (e.g. the result of ``measure``).
+        """
+        self._scope_for_variable(name).add(name)
+
     def _scope_for_variable(self, name: str) -> set[str]:
         """Return the MCM-dependency scope matching the declaration scope of ``name``.
 
@@ -1511,9 +1519,6 @@ class ProgramContext(AbstractProgramContext):
         """
         allow_remeasure = self.supports_midcircuit_measurement
         self._flush_pending_mcm_for_qubits(target)
-        if classical_destination is not None:
-            dest_name = get_identifier_name(classical_destination)
-            self._scope_for_variable(dest_name).add(dest_name)
         if self._is_branched:
             if classical_destination is not None:
                 self._measure_and_branch(target)

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -921,11 +921,12 @@ class AbstractProgramContext(ABC):
 
         An expression is MCM-dependent when any identifier it references
         resolves (via lexical scoping) to a variable that was produced by
-        a mid-circuit measurement. Subclasses populate
-        ``_mcm_dependent_scopes`` (typically via ``track_mcm_dependency``
-        or when a measurement is recorded) so this check walks each
-        referenced identifier's scope stack and stops at the scope where
-        the name is declared.
+        a mid-circuit measurement. ``_mcm_dependent_scopes`` is populated
+        by ``mark_mcm_dependent`` (for measurement destinations) and
+        ``track_mcm_dependency`` (for classical assignments that transfer
+        MCM-dependency from the rvalue to the lvalue); this check walks
+        each referenced identifier's scope stack and stops at the scope
+        where the name is declared.
 
         Used by the Interpreter to decide whether control flow and
         classical assignments need per-path evaluation. Expressions that

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -4695,3 +4695,68 @@ class TestClassicalControlGates:
         """
         with pytest.raises(ValueError, match="cc_prx references feedback key 7 but no measure_ff"):
             simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=100)
+
+
+class TestMCMDependencyTrackingOnAbstractContext:
+    """MCM-dependency tracking should work for any AbstractProgramContext
+    subclass that supports MCM — not just ``ProgramContext``. A translator
+    that wants to emit ``if (c == 1) {...}`` unchanged still needs the
+    dependency tracking so the Interpreter routes through the MCM path
+    instead of eagerly evaluating the uninitialized classical variable.
+    """
+
+    def test_translator_with_if_after_measure(self):
+        from braket.default_simulator.openqasm.circuit import Circuit
+        from braket.default_simulator.openqasm.interpreter import Interpreter
+        from braket.default_simulator.openqasm.program_context import AbstractProgramContext
+
+        class NoopMCMContext(AbstractProgramContext):
+            """MCM-capable context that stubs out every side-effecting hook."""
+
+            def __init__(self):
+                super().__init__()
+                self._circuit = Circuit()
+
+            @property
+            def circuit(self):
+                return self._circuit
+
+            @property
+            def supports_midcircuit_measurement(self) -> bool:
+                return True
+
+            def is_builtin_gate(self, name: str) -> bool:
+                return name in BRAKET_GATES
+
+            def add_phase_instruction(self, target, phase_value):
+                pass
+
+            def add_gate_instruction(self, gate_name, target, params, ctrl_modifiers, power):
+                pass
+
+            def add_measure(self, target, classical_targets=None, **kwargs):
+                pass
+
+            def evaluate_condition(self, condition):
+                # Translator doesn't care about per-path evaluation; it just
+                # wants both branches visited so it can emit the unchanged
+                # if/else. This mirrors what a QASM-to-QASM translator does.
+                yield True
+                yield False
+
+            def iter_classical_scopes(self, expression):
+                yield
+
+        qasm = """
+        OPENQASM 3.0;
+        qubit[3] q;
+        bit[2] c;
+        c[0] = measure q[0];
+        if (c[0] == 1) {
+            h q[1];
+        } else {
+            x q[2];
+        }
+        """
+        # Should not raise ``Identifier 'c' is not initialized``.
+        Interpreter(context=NoopMCMContext()).run(qasm)

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3728,69 +3728,6 @@ class SimpleProgramContext(AbstractProgramContext):
         self._circuit.add_instruction(instruction)
 
 
-def _render_type(type_node) -> str:
-    """Render a ClassicalType AST node as OpenQASM source."""
-    match type_node:
-        case BoolType():
-            return "bool"
-        case BitType(size=size):
-            return "bit" if size is None else f"bit[{_render_expression(size)}]"
-        case IntType(size=size):
-            return "int" if size is None else f"int[{_render_expression(size)}]"
-        case UintType(size=size):
-            return "uint" if size is None else f"uint[{_render_expression(size)}]"
-        case FloatType(size=size):
-            return "float" if size is None else f"float[{_render_expression(size)}]"
-    raise NotImplementedError(f"FlatProgramContext cannot render type {type_node!r}")
-
-
-def _render_expression(expr) -> str:
-    """Render an AST expression node as OpenQASM source."""
-    match expr:
-        case BooleanLiteral(value=value):
-            return "true" if value else "false"
-        case IntegerLiteral(value=value) | FloatLiteral(value=value):
-            return str(value)
-        case Identifier(name=name):
-            return name
-        case IndexedIdentifier(name=name, indices=indices):
-            parts = [
-                "[" + ", ".join(_render_expression(e) for e in group) + "]" for group in indices
-            ]
-            return _render_expression(name) + "".join(parts)
-        case IndexExpression(collection=collection, index=index):
-            return (
-                f"{_render_expression(collection)}"
-                f"[{', '.join(_render_expression(e) for e in index)}]"
-            )
-        case BinaryExpression(op=op, lhs=lhs, rhs=rhs):
-            return f"{_render_expression(lhs)} {op.name} {_render_expression(rhs)}"
-        case UnaryExpression(op=op, expression=inner):
-            return f"{op.name}{_render_expression(inner)}"
-        case ArrayLiteral(values=values):
-            return "{" + ", ".join(_render_expression(v) for v in values) + "}"
-        case RangeDefinition(start=start, end=end, step=step):
-            parts = [
-                _render_expression(start) if start is not None else "",
-                _render_expression(end) if end is not None else "",
-            ]
-            if step is not None:
-                parts.insert(1, _render_expression(step))
-            return "[" + ":".join(parts) + "]"
-        case DiscreteSet(values=values):
-            return "{" + ", ".join(_render_expression(v) for v in values) + "}"
-    raise NotImplementedError(f"FlatProgramContext cannot render expression {expr!r}")
-
-
-def _is_default_initializer(value) -> bool:
-    """Recognize implicit default initializers we don't need to emit."""
-    if value is None:
-        return True
-    if isinstance(value, ArrayLiteral):
-        return all(_is_default_initializer(item) for item in value.values)
-    return False
-
-
 class FlatProgramContext(AbstractProgramContext):
     """Translator context: emit OpenQASM mirroring the input.
 
@@ -3818,6 +3755,77 @@ class FlatProgramContext(AbstractProgramContext):
     def supports_midcircuit_measurement(self) -> bool:
         return True
 
+    @staticmethod
+    def _render_type(type_node) -> str:
+        """Render a ClassicalType AST node as OpenQASM source."""
+        match type_node:
+            case BoolType():
+                return "bool"
+            case BitType(size=size):
+                return (
+                    "bit" if size is None else f"bit[{FlatProgramContext._render_expression(size)}]"
+                )
+            case IntType(size=size):
+                return (
+                    "int" if size is None else f"int[{FlatProgramContext._render_expression(size)}]"
+                )
+            case UintType(size=size):
+                return (
+                    "uint"
+                    if size is None
+                    else f"uint[{FlatProgramContext._render_expression(size)}]"
+                )
+            case FloatType(size=size):
+                return (
+                    "float"
+                    if size is None
+                    else f"float[{FlatProgramContext._render_expression(size)}]"
+                )
+        raise NotImplementedError(f"FlatProgramContext cannot render type {type_node!r}")
+
+    @staticmethod
+    def _render_expression(expr) -> str:
+        """Render an AST expression node as OpenQASM source."""
+        render = FlatProgramContext._render_expression
+        match expr:
+            case BooleanLiteral(value=value):
+                return "true" if value else "false"
+            case IntegerLiteral(value=value) | FloatLiteral(value=value):
+                return str(value)
+            case Identifier(name=name):
+                return name
+            case IndexedIdentifier(name=name, indices=indices):
+                parts = ["[" + ", ".join(render(e) for e in group) + "]" for group in indices]
+                return render(name) + "".join(parts)
+            case IndexExpression(collection=collection, index=index):
+                return f"{render(collection)}[{', '.join(render(e) for e in index)}]"
+            case BinaryExpression(op=op, lhs=lhs, rhs=rhs):
+                return f"{render(lhs)} {op.name} {render(rhs)}"
+            case UnaryExpression(op=op, expression=inner):
+                return f"{op.name}{render(inner)}"
+            case ArrayLiteral(values=values):
+                return "{" + ", ".join(render(v) for v in values) + "}"
+            case RangeDefinition(start=start, end=end, step=step):
+                parts = [
+                    render(start) if start is not None else "",
+                    render(end) if end is not None else "",
+                ]
+                if step is not None:
+                    parts.insert(1, render(step))
+                return "[" + ":".join(parts) + "]"
+            case DiscreteSet(values=values):
+                return "{" + ", ".join(render(v) for v in values) + "}"
+        raise NotImplementedError(f"FlatProgramContext cannot render expression {expr!r}")
+
+    @staticmethod
+    def _is_default_initializer(value) -> bool:
+        """Recognize implicit default initializers we don't need to emit."""
+        if value is None:
+            return True
+        if isinstance(value, ArrayLiteral):
+            return all(FlatProgramContext._is_default_initializer(item) for item in value.values)
+        return False
+
     def _emit(self, line: str) -> None:
         self._lines.append("    " * self._indent + line)
 
@@ -3836,15 +3844,15 @@ class FlatProgramContext(AbstractProgramContext):
     def declare_variable(self, name, symbol_type, value=None, const=False):
         super().declare_variable(name, symbol_type, value, const)
         prefix = "const " if const else ""
-        type_str = _render_type(symbol_type)
-        if _is_default_initializer(value):
+        type_str = self._render_type(symbol_type)
+        if self._is_default_initializer(value):
             self._emit(f"{prefix}{type_str} {name};")
         else:
-            self._emit(f"{prefix}{type_str} {name} = {_render_expression(value)};")
+            self._emit(f"{prefix}{type_str} {name} = {self._render_expression(value)};")
 
     def update_value(self, variable, value):
         super().update_value(variable, value)
-        self._emit(f"{_render_expression(variable)} = {_render_expression(value)};")
+        self._emit(f"{self._render_expression(variable)} = {self._render_expression(value)};")
 
     def add_phase_instruction(self, target, phase_value):
         self._emit(f"gphase({phase_value});")
@@ -3856,14 +3864,14 @@ class FlatProgramContext(AbstractProgramContext):
     def add_measure(self, target, classical_targets=None, *, classical_destination=None, **kwargs):
         target_str = self._render_target(target)
         if classical_destination is not None:
-            self._emit(f"{_render_expression(classical_destination)} = measure {target_str};")
+            self._emit(f"{self._render_expression(classical_destination)} = measure {target_str};")
         else:
             self._emit(f"measure {target_str};")
 
     def evaluate_condition(self, condition):
         """Emit ``if (cond) { ... } else { ... }`` around the interpreter's
         visits of the two branches."""
-        self._emit(f"if ({_render_expression(condition)}) {{")
+        self._emit(f"if ({self._render_expression(condition)}) {{")
         self._indent += 1
         yield True
         self._indent -= 1
@@ -3876,7 +3884,8 @@ class FlatProgramContext(AbstractProgramContext):
     def evaluate_for_range(self, set_declaration, loop_var, loop_type):
         """Emit ``for <type> <var> in <range> { ... }`` around the visit of the body."""
         self._emit(
-            f"for {_render_type(loop_type)} {loop_var} in {_render_expression(set_declaration)} {{"
+            f"for {self._render_type(loop_type)} {loop_var} in "
+            f"{self._render_expression(set_declaration)} {{"
         )
         self._indent += 1
         yield
@@ -3885,7 +3894,7 @@ class FlatProgramContext(AbstractProgramContext):
 
     def evaluate_while_condition(self, condition):
         """Emit ``while (cond) { ... }`` around the visit of the body."""
-        self._emit(f"while ({_render_expression(condition)}) {{")
+        self._emit(f"while ({self._render_expression(condition)}) {{")
         self._indent += 1
         yield
         self._indent -= 1
@@ -4904,23 +4913,28 @@ class TestMCMDependencyTrackingOnAbstractContext:
         """Non-MCM ``if`` statements are replaced by the taken branch only:
         the true branch's body for the true-condition if, the else body for
         the false-condition if. Both appear in their source order."""
-        assert Interpreter(context=FlatProgramContext()).run(
-            (
-                "OPENQASM 3.0;\n"
-                "qubit[2] q;\n"
-                "int x = 7;\n"
-                "if (x == 7) {\n"
-                "    h q[0];\n"
-                "} else {\n"
-                "    x q[0];\n"
-                "}\n"
-                "if (x == 5) {\n"
-                "    h q[1];\n"
-                "} else {\n"
-                "    x q[1];\n"
-                "}"
+        assert (
+            Interpreter(context=FlatProgramContext())
+            .run(
+                (
+                    "OPENQASM 3.0;\n"
+                    "qubit[2] q;\n"
+                    "int x = 7;\n"
+                    "if (x == 7) {\n"
+                    "    h q[0];\n"
+                    "} else {\n"
+                    "    x q[0];\n"
+                    "}\n"
+                    "if (x == 5) {\n"
+                    "    h q[1];\n"
+                    "} else {\n"
+                    "    x q[1];\n"
+                    "}"
+                )
             )
-        ).circuit == "OPENQASM 3.0;\nqubit[2] q;\nint x = 7;\nh q[0];\nx q[1];"
+            .circuit
+            == "OPENQASM 3.0;\nqubit[2] q;\nint x = 7;\nh q[0];\nx q[1];"
+        )
 
     def test_flat_context_unrolls_non_mcm_for_loop(self):
         """A for-loop with a compile-time constant range is unrolled inline."""
@@ -4953,17 +4967,22 @@ class TestMCMDependencyTrackingOnAbstractContext:
 
     def test_flat_context_unrolls_non_mcm_while_loop(self):
         """A while-loop with a compile-time constant condition is unrolled inline."""
-        assert Interpreter(context=FlatProgramContext()).run(
-            (
-                "OPENQASM 3.0;\n"
-                "qubit[1] q;\n"
-                "int i = 0;\n"
-                "while (i < 2) {\n"
-                "    h q[0];\n"
-                "    i = i + 1;\n"
-                "}"
+        assert (
+            Interpreter(context=FlatProgramContext())
+            .run(
+                (
+                    "OPENQASM 3.0;\n"
+                    "qubit[1] q;\n"
+                    "int i = 0;\n"
+                    "while (i < 2) {\n"
+                    "    h q[0];\n"
+                    "    i = i + 1;\n"
+                    "}"
+                )
             )
-        ).circuit == "OPENQASM 3.0;\nqubit[1] q;\nint i = 0;\nh q[0];\ni = 1;\nh q[0];\ni = 2;"
+            .circuit
+            == "OPENQASM 3.0;\nqubit[1] q;\nint i = 0;\nh q[0];\ni = 1;\nh q[0];\ni = 2;"
+        )
 
     def test_flat_context_preserves_mcm_while_loop(self):
         """A while-loop whose condition depends on a measurement result is emitted verbatim.

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3817,7 +3817,7 @@ class FlatProgramContext(AbstractProgramContext):
         self._lines.append("    " * self._indent + line)
 
     def _render_target(self, target) -> str:
-        # TODO: Add support for named registers in targets in AbstractProgramContext
+        # TODO: Support named target registers in AbstractProgramContext
         return ", ".join(f"q[{q}]" for q in target)
 
     @staticmethod
@@ -3837,7 +3837,7 @@ class FlatProgramContext(AbstractProgramContext):
             case FloatType(size=size):
                 arr = "" if size is None else f"[{FlatProgramContext._render_expression(size)}]"
                 return f"float{arr}"
-        raise NotImplementedError(f"Unsupported type {type_node!r}")
+        raise NotImplementedError(f"Unsupported type {type_node}")
 
     @staticmethod
     def _render_expression(expr) -> str:
@@ -3868,7 +3868,7 @@ class FlatProgramContext(AbstractProgramContext):
                 return f"[{left}{middle}{right}]"
             case DiscreteSet(values=values):
                 return "{" + ", ".join(render(v) for v in values) + "}"
-        raise NotImplementedError(f"Unsupported expression {expr!r}")
+        raise NotImplementedError(f"Unsupported expression {expr}")
 
     @staticmethod
     def _is_default_initializer(value) -> bool:

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3730,16 +3730,17 @@ class SimpleProgramContext(AbstractProgramContext):
 
 def _render_type(type_node) -> str:
     """Render a ClassicalType AST node as OpenQASM source."""
-    if isinstance(type_node, BitType):
-        return "bit" if type_node.size is None else f"bit[{_render_expression(type_node.size)}]"
-    if isinstance(type_node, BoolType):
-        return "bool"
-    if isinstance(type_node, IntType):
-        return "int" if type_node.size is None else f"int[{_render_expression(type_node.size)}]"
-    if isinstance(type_node, UintType):
-        return "uint" if type_node.size is None else f"uint[{_render_expression(type_node.size)}]"
-    if isinstance(type_node, FloatType):
-        return "float" if type_node.size is None else f"float[{_render_expression(type_node.size)}]"
+    match type_node:
+        case BoolType():
+            return "bool"
+        case BitType(size=size):
+            return "bit" if size is None else f"bit[{_render_expression(size)}]"
+        case IntType(size=size):
+            return "int" if size is None else f"int[{_render_expression(size)}]"
+        case UintType(size=size):
+            return "uint" if size is None else f"uint[{_render_expression(size)}]"
+        case FloatType(size=size):
+            return "float" if size is None else f"float[{_render_expression(size)}]"
     raise NotImplementedError(f"FlatProgramContext cannot render type {type_node!r}")
 
 
@@ -4897,22 +4898,13 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "    x q[2];\n"
             "}"
         )
-        context = FlatProgramContext()
-        Interpreter(context=context).run(qasm)
-        assert context.circuit == qasm
+        Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
 
     def test_flat_context_unrolls_non_mcm_for_loop(self):
         """A for-loop with a compile-time constant range is unrolled inline."""
-        qasm = """
-        OPENQASM 3.0;
-        qubit[1] q;
-        for int i in [0:2] {
-            h q[0];
-        }
-        """
-        context = FlatProgramContext()
-        Interpreter(context=context).run(qasm)
-        expected = (
+        Interpreter(context=FlatProgramContext()).run(
+            ("OPENQASM 3.0;\nqubit[1] q;\nfor int i in [0:2] {\n    h q[0];\n}")
+        ).circuit == (
             "OPENQASM 3.0;\n"
             "qubit[1] q;\n"
             "int i = 0;\n"
@@ -4922,7 +4914,6 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "int i = 2;\n"
             "h q[0];"
         )
-        assert context.circuit == expected
 
     def test_flat_context_preserves_mcm_for_loop(self):
         """A for-loop whose range depends on a measurement result is emitted verbatim."""
@@ -4936,25 +4927,21 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "    h q[1];\n"
             "}"
         )
-        context = FlatProgramContext()
-        Interpreter(context=context).run(qasm)
-        assert context.circuit == qasm
+        Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
 
     def test_flat_context_unrolls_non_mcm_while_loop(self):
         """A while-loop with a compile-time constant condition is unrolled inline."""
-        qasm = """
-        OPENQASM 3.0;
-        qubit[1] q;
-        int i = 0;
-        while (i < 2) {
-            h q[0];
-            i = i + 1;
-        }
-        """
-        context = FlatProgramContext()
-        Interpreter(context=context).run(qasm)
-        expected = "OPENQASM 3.0;\nqubit[1] q;\nint i = 0;\nh q[0];\ni = 1;\nh q[0];\ni = 2;"
-        assert context.circuit == expected
+        Interpreter(context=FlatProgramContext()).run(
+            (
+                "OPENQASM 3.0;\n"
+                "qubit[1] q;\n"
+                "int i = 0;\n"
+                "while (i < 2) {\n"
+                "    h q[0];\n"
+                "    i = i + 1;\n"
+                "}"
+            )
+        ).circuit == ("OPENQASM 3.0;\nqubit[1] q;\nint i = 0;\nh q[0];\ni = 1;\nh q[0];\ni = 2;")
 
     def test_flat_context_preserves_mcm_while_loop(self):
         """A while-loop whose condition depends on a measurement result is emitted verbatim.
@@ -4972,6 +4959,4 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "    c[0] = measure q[0];\n"
             "}"
         )
-        context = FlatProgramContext()
-        Interpreter(context=context).run(qasm)
-        assert context.circuit == qasm
+        Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3845,6 +3845,7 @@ class FlatProgramContext(AbstractProgramContext):
         super().update_value(variable, value)
         self._emit(f"{_render_expression(variable)} = {_render_expression(value)};")
 
+    def add_phase_instruction(self, target, phase_value):
         self._emit(f"gphase({phase_value});")
 
     def add_gate_instruction(self, gate_name, target, params, ctrl_modifiers, power):

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -18,10 +18,22 @@ from braket.default_simulator.gate_operations import BRAKET_GATES, GPhase
 from braket.default_simulator.openqasm.circuit import Circuit
 from braket.default_simulator.openqasm.interpreter import Interpreter
 from braket.default_simulator.openqasm.parser.openqasm_ast import (
+    ArrayLiteral,
+    BinaryExpression,
+    BitType,
+    BoolType,
     BooleanLiteral,
+    DiscreteSet,
+    FloatLiteral,
+    FloatType,
+    Identifier,
+    IndexExpression,
+    IndexedIdentifier,
     IntegerLiteral,
     IntType,
     RangeDefinition,
+    UintType,
+    UnaryExpression,
 )
 from braket.default_simulator.openqasm.program_context import AbstractProgramContext
 from braket.default_simulator.state_vector_simulator import StateVectorSimulator
@@ -3716,6 +3728,171 @@ class SimpleProgramContext(AbstractProgramContext):
         self._circuit.add_instruction(instruction)
 
 
+def _render_type(type_node) -> str:
+    """Render a ClassicalType AST node as OpenQASM source."""
+    if isinstance(type_node, BitType):
+        return "bit" if type_node.size is None else f"bit[{_render_expression(type_node.size)}]"
+    if isinstance(type_node, BoolType):
+        return "bool"
+    if isinstance(type_node, IntType):
+        return "int" if type_node.size is None else f"int[{_render_expression(type_node.size)}]"
+    if isinstance(type_node, UintType):
+        return "uint" if type_node.size is None else f"uint[{_render_expression(type_node.size)}]"
+    if isinstance(type_node, FloatType):
+        return "float" if type_node.size is None else f"float[{_render_expression(type_node.size)}]"
+    raise NotImplementedError(f"FlatProgramContext cannot render type {type_node!r}")
+
+
+def _render_expression(expr) -> str:
+    """Render an AST expression node as OpenQASM source."""
+    match expr:
+        case BooleanLiteral(value=value):
+            return "true" if value else "false"
+        case IntegerLiteral(value=value) | FloatLiteral(value=value):
+            return str(value)
+        case Identifier(name=name):
+            return name
+        case IndexedIdentifier(name=name, indices=indices):
+            parts = [
+                "[" + ", ".join(_render_expression(e) for e in group) + "]" for group in indices
+            ]
+            return _render_expression(name) + "".join(parts)
+        case IndexExpression(collection=collection, index=index):
+            return (
+                f"{_render_expression(collection)}"
+                f"[{', '.join(_render_expression(e) for e in index)}]"
+            )
+        case BinaryExpression(op=op, lhs=lhs, rhs=rhs):
+            return f"{_render_expression(lhs)} {op.name} {_render_expression(rhs)}"
+        case UnaryExpression(op=op, expression=inner):
+            return f"{op.name}{_render_expression(inner)}"
+        case ArrayLiteral(values=values):
+            return "{" + ", ".join(_render_expression(v) for v in values) + "}"
+        case RangeDefinition(start=start, end=end, step=step):
+            parts = [
+                _render_expression(start) if start is not None else "",
+                _render_expression(end) if end is not None else "",
+            ]
+            if step is not None:
+                parts.insert(1, _render_expression(step))
+            return "[" + ":".join(parts) + "]"
+        case DiscreteSet(values=values):
+            return "{" + ", ".join(_render_expression(v) for v in values) + "}"
+    raise NotImplementedError(f"FlatProgramContext cannot render expression {expr!r}")
+
+
+def _is_default_initializer(value) -> bool:
+    """Recognize implicit default initializers we don't need to emit."""
+    if value is None:
+        return True
+    if isinstance(value, ArrayLiteral):
+        return all(_is_default_initializer(item) for item in value.values)
+    return False
+
+
+class FlatProgramContext(AbstractProgramContext):
+    """Translator context: emit OpenQASM mirroring the input.
+
+    Pure classical control flow (``if (x == 7) {...}``, ``for int i in [0:3]``)
+    is unrolled by the Interpreter's default path and emerges as a flat
+    sequence of gate/measurement lines. MCM-dependent control flow
+    (``if (c == 1) {...}`` after ``c = measure q``) is preserved verbatim
+    because ``supports_midcircuit_measurement`` is ``True`` and the
+    interpreter routes those statements through ``evaluate_condition``,
+    where we emit the surrounding ``if``/``else`` braces around the visits
+    of the two branches.
+    """
+
+    def __init__(self, qubit_register_name: str = "q"):
+        super().__init__()
+        self._qubit_register_name = qubit_register_name
+        self._lines: list[str] = ["OPENQASM 3.0;"]
+        self._indent = 0
+
+    @property
+    def circuit(self) -> str:
+        return "\n".join(self._lines)
+
+    @property
+    def supports_midcircuit_measurement(self) -> bool:
+        return True
+
+    def _emit(self, line: str) -> None:
+        self._lines.append("    " * self._indent + line)
+
+    def _render_target(self, target) -> str:
+        if len(target) == 1:
+            return f"{self._qubit_register_name}[{target[0]}]"
+        return ", ".join(f"{self._qubit_register_name}[{q}]" for q in target)
+
+    def is_builtin_gate(self, name: str) -> bool:
+        return name in BRAKET_GATES
+
+    def add_qubits(self, name: str, num_qubits: int | None = 1) -> None:
+        super().add_qubits(name, num_qubits)
+        self._emit(f"qubit[{num_qubits}] {name};")
+
+    def declare_variable(self, name, symbol_type, value=None, const=False):
+        super().declare_variable(name, symbol_type, value, const)
+        prefix = "const " if const else ""
+        type_str = _render_type(symbol_type)
+        if _is_default_initializer(value):
+            self._emit(f"{prefix}{type_str} {name};")
+        else:
+            self._emit(f"{prefix}{type_str} {name} = {_render_expression(value)};")
+
+    def update_value(self, variable, value):
+        super().update_value(variable, value)
+        self._emit(f"{_render_expression(variable)} = {_render_expression(value)};")
+
+        self._emit(f"gphase({phase_value});")
+
+    def add_gate_instruction(self, gate_name, target, params, ctrl_modifiers, power):
+        args = f"({', '.join(str(p) for p in params)})" if len(params) else ""
+        self._emit(f"{gate_name}{args} {self._render_target(target)};")
+
+    def add_measure(self, target, classical_targets=None, *, classical_destination=None, **kwargs):
+        target_str = self._render_target(target)
+        if classical_destination is not None:
+            self._emit(f"{_render_expression(classical_destination)} = measure {target_str};")
+        else:
+            self._emit(f"measure {target_str};")
+
+    def evaluate_condition(self, condition):
+        """Emit ``if (cond) { ... } else { ... }`` around the interpreter's
+        visits of the two branches."""
+        self._emit(f"if ({_render_expression(condition)}) {{")
+        self._indent += 1
+        yield True
+        self._indent -= 1
+        self._emit("} else {")
+        self._indent += 1
+        yield False
+        self._indent -= 1
+        self._emit("}")
+
+    def evaluate_for_range(self, set_declaration, loop_var, loop_type):
+        """Emit ``for <type> <var> in <range> { ... }`` around the visit of the body."""
+        self._emit(
+            f"for {_render_type(loop_type)} {loop_var} in {_render_expression(set_declaration)} {{"
+        )
+        self._indent += 1
+        yield
+        self._indent -= 1
+        self._emit("}")
+
+    def evaluate_while_condition(self, condition):
+        """Emit ``while (cond) { ... }`` around the visit of the body."""
+        self._emit(f"while ({_render_expression(condition)}) {{")
+        self._indent += 1
+        yield
+        self._indent -= 1
+        self._emit("}")
+
+    def iter_classical_scopes(self, expression):
+        yield
+
+
 class TestAbstractContextControlFlow:
     """Tests for AbstractProgramContext defaults via SimpleProgramContext."""
 
@@ -4700,63 +4877,100 @@ class TestClassicalControlGates:
 class TestMCMDependencyTrackingOnAbstractContext:
     """MCM-dependency tracking should work for any AbstractProgramContext
     subclass that supports MCM — not just ``ProgramContext``. A translator
-    that wants to emit ``if (c == 1) {...}`` unchanged still needs the
-    dependency tracking so the Interpreter routes through the MCM path
-    instead of eagerly evaluating the uninitialized classical variable.
+    that emits the unchanged ``if (c == 1) {...}`` still relies on the
+    tracking so the Interpreter routes through the MCM path instead of
+    eagerly evaluating the uninitialized classical variable.
     """
 
-    def test_translator_with_if_after_measure(self):
-        from braket.default_simulator.openqasm.circuit import Circuit
-        from braket.default_simulator.openqasm.interpreter import Interpreter
-        from braket.default_simulator.openqasm.program_context import AbstractProgramContext
+    def test_flat_context_emits_if_else_after_measure(self):
+        """``FlatProgramContext`` preserves MCM-dependent if/else statements
+        verbatim while unrolling purely classical control flow."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "qubit[3] q;\n"
+            "bit[2] c;\n"
+            "c[0] = measure q[0];\n"
+            "if (c[0] == 1) {\n"
+            "    h q[1];\n"
+            "} else {\n"
+            "    x q[2];\n"
+            "}"
+        )
+        context = FlatProgramContext()
+        Interpreter(context=context).run(qasm)
+        assert context.circuit == qasm
 
-        class NoopMCMContext(AbstractProgramContext):
-            """MCM-capable context that stubs out every side-effecting hook."""
-
-            def __init__(self):
-                super().__init__()
-                self._circuit = Circuit()
-
-            @property
-            def circuit(self):
-                return self._circuit
-
-            @property
-            def supports_midcircuit_measurement(self) -> bool:
-                return True
-
-            def is_builtin_gate(self, name: str) -> bool:
-                return name in BRAKET_GATES
-
-            def add_phase_instruction(self, target, phase_value):
-                pass
-
-            def add_gate_instruction(self, gate_name, target, params, ctrl_modifiers, power):
-                pass
-
-            def add_measure(self, target, classical_targets=None, **kwargs):
-                pass
-
-            def evaluate_condition(self, condition):
-                # Translator doesn't care about per-path evaluation; it just
-                # wants both branches visited so it can emit the unchanged
-                # if/else. This mirrors what a QASM-to-QASM translator does.
-                yield True
-                yield False
-
-            def iter_classical_scopes(self, expression):
-                yield
-
+    def test_flat_context_unrolls_non_mcm_for_loop(self):
+        """A for-loop with a compile-time constant range is unrolled inline."""
         qasm = """
         OPENQASM 3.0;
-        qubit[3] q;
-        bit[2] c;
-        c[0] = measure q[0];
-        if (c[0] == 1) {
-            h q[1];
-        } else {
-            x q[2];
+        qubit[1] q;
+        for int i in [0:2] {
+            h q[0];
         }
         """
-        # Should not raise ``Identifier 'c' is not initialized``.
-        Interpreter(context=NoopMCMContext()).run(qasm)
+        context = FlatProgramContext()
+        Interpreter(context=context).run(qasm)
+        expected = (
+            "OPENQASM 3.0;\n"
+            "qubit[1] q;\n"
+            "int i = 0;\n"
+            "h q[0];\n"
+            "int i = 1;\n"
+            "h q[0];\n"
+            "int i = 2;\n"
+            "h q[0];"
+        )
+        assert context.circuit == expected
+
+    def test_flat_context_preserves_mcm_for_loop(self):
+        """A for-loop whose range depends on a measurement result is emitted verbatim."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "qubit[2] q;\n"
+            "bit[1] c;\n"
+            "c[0] = measure q[0];\n"
+            "h q[1];\n"
+            "for int i in [0:c[0]] {\n"
+            "    h q[1];\n"
+            "}"
+        )
+        context = FlatProgramContext()
+        Interpreter(context=context).run(qasm)
+        assert context.circuit == qasm
+
+    def test_flat_context_unrolls_non_mcm_while_loop(self):
+        """A while-loop with a compile-time constant condition is unrolled inline."""
+        qasm = """
+        OPENQASM 3.0;
+        qubit[1] q;
+        int i = 0;
+        while (i < 2) {
+            h q[0];
+            i = i + 1;
+        }
+        """
+        context = FlatProgramContext()
+        Interpreter(context=context).run(qasm)
+        expected = "OPENQASM 3.0;\nqubit[1] q;\nint i = 0;\nh q[0];\ni = 1;\nh q[0];\ni = 2;"
+        assert context.circuit == expected
+
+    def test_flat_context_preserves_mcm_while_loop(self):
+        """A while-loop whose condition depends on a measurement result is emitted verbatim.
+
+        The loop re-measures the same qubit after an ``h`` each iteration and
+        terminates when the outcome is ``1`` — a classic flip-until-1 pattern.
+        """
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "qubit[1] q;\n"
+            "bit[1] c;\n"
+            "c[0] = measure q[0];\n"
+            "while (c[0] == 0) {\n"
+            "    h q[0];\n"
+            "    c[0] = measure q[0];\n"
+            "}"
+        )
+        context = FlatProgramContext()
+        Interpreter(context=context).run(qasm)
+        assert context.circuit == qasm

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -4920,7 +4920,7 @@ class TestMCMDependencyTrackingOnAbstractContext:
                 "    x q[1];\n"
                 "}"
             )
-        ).circuit == ("OPENQASM 3.0;\nqubit[2] q;\nint x = 7;\nh q[0];\nx q[1];")
+        ).circuit == "OPENQASM 3.0;\nqubit[2] q;\nint x = 7;\nh q[0];\nx q[1];"
 
     def test_flat_context_unrolls_non_mcm_for_loop(self):
         """A for-loop with a compile-time constant range is unrolled inline."""
@@ -4963,7 +4963,7 @@ class TestMCMDependencyTrackingOnAbstractContext:
                 "    i = i + 1;\n"
                 "}"
             )
-        ).circuit == ("OPENQASM 3.0;\nqubit[1] q;\nint i = 0;\nh q[0];\ni = 1;\nh q[0];\ni = 2;")
+        ).circuit == "OPENQASM 3.0;\nqubit[1] q;\nint i = 0;\nh q[0];\ni = 1;\nh q[0];\ni = 2;"
 
     def test_flat_context_preserves_mcm_while_loop(self):
         """A while-loop whose condition depends on a measurement result is emitted verbatim.

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -4898,11 +4898,38 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "    x q[2];\n"
             "}"
         )
-        Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
+        assert Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
+
+    def test_flat_context_unrolls_non_mcm_if_statements(self):
+        """Non-MCM ``if`` statements are replaced by the taken branch only:
+        the true branch's body for the true-condition if, the else body for
+        the false-condition if. Both appear in their source order."""
+        assert (
+            Interpreter(context=FlatProgramContext())
+            .run(
+                (
+                    "OPENQASM 3.0;\n"
+                    "qubit[2] q;\n"
+                    "int x = 7;\n"
+                    "if (x == 7) {\n"
+                    "    h q[0];\n"
+                    "} else {\n"
+                    "    x q[0];\n"
+                    "}\n"
+                    "if (x == 5) {\n"
+                    "    h q[1];\n"
+                    "} else {\n"
+                    "    x q[1];\n"
+                    "}"
+                )
+            )
+            .circuit
+            == "OPENQASM 3.0;\nqubit[2] q;\nint x = 7;\nh q[0];\nx q[1];"
+        )
 
     def test_flat_context_unrolls_non_mcm_for_loop(self):
         """A for-loop with a compile-time constant range is unrolled inline."""
-        Interpreter(context=FlatProgramContext()).run(
+        assert Interpreter(context=FlatProgramContext()).run(
             ("OPENQASM 3.0;\nqubit[1] q;\nfor int i in [0:2] {\n    h q[0];\n}")
         ).circuit == (
             "OPENQASM 3.0;\n"
@@ -4927,11 +4954,11 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "    h q[1];\n"
             "}"
         )
-        Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
+        assert Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
 
     def test_flat_context_unrolls_non_mcm_while_loop(self):
         """A while-loop with a compile-time constant condition is unrolled inline."""
-        Interpreter(context=FlatProgramContext()).run(
+        assert Interpreter(context=FlatProgramContext()).run(
             (
                 "OPENQASM 3.0;\n"
                 "qubit[1] q;\n"
@@ -4959,4 +4986,4 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "    c[0] = measure q[0];\n"
             "}"
         )
-        Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
+        assert Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -4904,28 +4904,23 @@ class TestMCMDependencyTrackingOnAbstractContext:
         """Non-MCM ``if`` statements are replaced by the taken branch only:
         the true branch's body for the true-condition if, the else body for
         the false-condition if. Both appear in their source order."""
-        assert (
-            Interpreter(context=FlatProgramContext())
-            .run(
-                (
-                    "OPENQASM 3.0;\n"
-                    "qubit[2] q;\n"
-                    "int x = 7;\n"
-                    "if (x == 7) {\n"
-                    "    h q[0];\n"
-                    "} else {\n"
-                    "    x q[0];\n"
-                    "}\n"
-                    "if (x == 5) {\n"
-                    "    h q[1];\n"
-                    "} else {\n"
-                    "    x q[1];\n"
-                    "}"
-                )
+        assert Interpreter(context=FlatProgramContext()).run(
+            (
+                "OPENQASM 3.0;\n"
+                "qubit[2] q;\n"
+                "int x = 7;\n"
+                "if (x == 7) {\n"
+                "    h q[0];\n"
+                "} else {\n"
+                "    x q[0];\n"
+                "}\n"
+                "if (x == 5) {\n"
+                "    h q[1];\n"
+                "} else {\n"
+                "    x q[1];\n"
+                "}"
             )
-            .circuit
-            == "OPENQASM 3.0;\nqubit[2] q;\nint x = 7;\nh q[0];\nx q[1];"
-        )
+        ).circuit == ("OPENQASM 3.0;\nqubit[2] q;\nint x = 7;\nh q[0];\nx q[1];")
 
     def test_flat_context_unrolls_non_mcm_for_loop(self):
         """A for-loop with a compile-time constant range is unrolled inline."""

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3844,7 +3844,7 @@ class FlatProgramContext(AbstractProgramContext):
         render = FlatProgramContext._render_expression
         match expr:
             case BooleanLiteral(value=value):
-                return "true" if value else "false"
+                return str(value).lower()
             case IntegerLiteral(value=value) | FloatLiteral(value=value):
                 return str(value)
             case Identifier(name=name):

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3729,22 +3729,14 @@ class SimpleProgramContext(AbstractProgramContext):
 
 
 class FlatProgramContext(AbstractProgramContext):
-    """Translator context: emit OpenQASM mirroring the input.
-
-    Pure classical control flow (``if (x == 7) {...}``, ``for int i in [0:3]``)
-    is unrolled by the Interpreter's default path and emerges as a flat
-    sequence of gate/measurement lines. MCM-dependent control flow
-    (``if (c == 1) {...}`` after ``c = measure q``) is preserved verbatim
-    because ``supports_midcircuit_measurement`` is ``True`` and the
-    interpreter routes those statements through ``evaluate_condition``,
-    where we emit the surrounding ``if``/``else`` braces around the visits
-    of the two branches.
+    """
+    Translates an OpenQASM program into the same OpenQASM program, but with purely classical control
+    flow statements fully evaluated; loops are unrolled and unused branches eliminated.
     """
 
-    def __init__(self, qubit_register_name: str = "q"):
+    def __init__(self):
         super().__init__()
-        self._qubit_register_name = qubit_register_name
-        self._lines: list[str] = ["OPENQASM 3.0;"]
+        self._lines = ["OPENQASM 3.0;"]
         self._indent = 0
 
     @property
@@ -3755,104 +3747,8 @@ class FlatProgramContext(AbstractProgramContext):
     def supports_midcircuit_measurement(self) -> bool:
         return True
 
-    @staticmethod
-    def _render_type(type_node) -> str:
-        """Render a ClassicalType AST node as OpenQASM source."""
-        match type_node:
-            case BoolType():
-                return "bool"
-            case BitType(size=size):
-                return (
-                    "bit" if size is None else f"bit[{FlatProgramContext._render_expression(size)}]"
-                )
-            case IntType(size=size):
-                return (
-                    "int" if size is None else f"int[{FlatProgramContext._render_expression(size)}]"
-                )
-            case UintType(size=size):
-                return (
-                    "uint"
-                    if size is None
-                    else f"uint[{FlatProgramContext._render_expression(size)}]"
-                )
-            case FloatType(size=size):
-                return (
-                    "float"
-                    if size is None
-                    else f"float[{FlatProgramContext._render_expression(size)}]"
-                )
-        raise NotImplementedError(f"FlatProgramContext cannot render type {type_node!r}")
-
-    @staticmethod
-    def _render_expression(expr) -> str:
-        """Render an AST expression node as OpenQASM source."""
-        render = FlatProgramContext._render_expression
-        match expr:
-            case BooleanLiteral(value=value):
-                return "true" if value else "false"
-            case IntegerLiteral(value=value) | FloatLiteral(value=value):
-                return str(value)
-            case Identifier(name=name):
-                return name
-            case IndexedIdentifier(name=name, indices=indices):
-                parts = ["[" + ", ".join(render(e) for e in group) + "]" for group in indices]
-                return render(name) + "".join(parts)
-            case IndexExpression(collection=collection, index=index):
-                return f"{render(collection)}[{', '.join(render(e) for e in index)}]"
-            case BinaryExpression(op=op, lhs=lhs, rhs=rhs):
-                return f"{render(lhs)} {op.name} {render(rhs)}"
-            case UnaryExpression(op=op, expression=inner):
-                return f"{op.name}{render(inner)}"
-            case ArrayLiteral(values=values):
-                return "{" + ", ".join(render(v) for v in values) + "}"
-            case RangeDefinition(start=start, end=end, step=step):
-                parts = [
-                    render(start) if start is not None else "",
-                    render(end) if end is not None else "",
-                ]
-                if step is not None:
-                    parts.insert(1, render(step))
-                return "[" + ":".join(parts) + "]"
-            case DiscreteSet(values=values):
-                return "{" + ", ".join(render(v) for v in values) + "}"
-        raise NotImplementedError(f"FlatProgramContext cannot render expression {expr!r}")
-
-    @staticmethod
-    def _is_default_initializer(value) -> bool:
-        """Recognize implicit default initializers we don't need to emit."""
-        if value is None:
-            return True
-        if isinstance(value, ArrayLiteral):
-            return all(FlatProgramContext._is_default_initializer(item) for item in value.values)
-        return False
-
-    def _emit(self, line: str) -> None:
-        self._lines.append("    " * self._indent + line)
-
-    def _render_target(self, target) -> str:
-        if len(target) == 1:
-            return f"{self._qubit_register_name}[{target[0]}]"
-        return ", ".join(f"{self._qubit_register_name}[{q}]" for q in target)
-
     def is_builtin_gate(self, name: str) -> bool:
         return name in BRAKET_GATES
-
-    def add_qubits(self, name: str, num_qubits: int | None = 1) -> None:
-        super().add_qubits(name, num_qubits)
-        self._emit(f"qubit[{num_qubits}] {name};")
-
-    def declare_variable(self, name, symbol_type, value=None, const=False):
-        super().declare_variable(name, symbol_type, value, const)
-        prefix = "const " if const else ""
-        type_str = self._render_type(symbol_type)
-        if self._is_default_initializer(value):
-            self._emit(f"{prefix}{type_str} {name};")
-        else:
-            self._emit(f"{prefix}{type_str} {name} = {self._render_expression(value)};")
-
-    def update_value(self, variable, value):
-        super().update_value(variable, value)
-        self._emit(f"{self._render_expression(variable)} = {self._render_expression(value)};")
 
     def add_phase_instruction(self, target, phase_value):
         self._emit(f"gphase({phase_value});")
@@ -3862,27 +3758,25 @@ class FlatProgramContext(AbstractProgramContext):
         self._emit(f"{gate_name}{args} {self._render_target(target)};")
 
     def add_measure(self, target, classical_targets=None, *, classical_destination=None, **kwargs):
-        target_str = self._render_target(target)
-        if classical_destination is not None:
-            self._emit(f"{self._render_expression(classical_destination)} = measure {target_str};")
-        else:
-            self._emit(f"measure {target_str};")
+        lhs = (
+            ""
+            if classical_destination is None
+            else f"{self._render_expression(classical_destination)} = "
+        )
+        self._emit(f"{lhs}measure {self._render_target(target)};")
 
     def evaluate_condition(self, condition):
-        """Emit ``if (cond) { ... } else { ... }`` around the interpreter's
-        visits of the two branches."""
         self._emit(f"if ({self._render_expression(condition)}) {{")
         self._indent += 1
         yield True
         self._indent -= 1
-        self._emit("} else {")
+        self._emit("} else {")  # Assume there's an else statement for simplicity
         self._indent += 1
         yield False
         self._indent -= 1
         self._emit("}")
 
     def evaluate_for_range(self, set_declaration, loop_var, loop_type):
-        """Emit ``for <type> <var> in <range> { ... }`` around the visit of the body."""
         self._emit(
             f"for {self._render_type(loop_type)} {loop_var} in "
             f"{self._render_expression(set_declaration)} {{"
@@ -3893,7 +3787,6 @@ class FlatProgramContext(AbstractProgramContext):
         self._emit("}")
 
     def evaluate_while_condition(self, condition):
-        """Emit ``while (cond) { ... }`` around the visit of the body."""
         self._emit(f"while ({self._render_expression(condition)}) {{")
         self._indent += 1
         yield
@@ -3902,6 +3795,88 @@ class FlatProgramContext(AbstractProgramContext):
 
     def iter_classical_scopes(self, expression):
         yield
+
+    # We don't need to subclass the three following public methods for functional equivalence;
+    # we do it here only to simplify verbatim reproduction of the input program
+
+    def add_qubits(self, name: str, num_qubits: int | None = 1) -> None:
+        super().add_qubits(name, num_qubits)
+        self._emit(f"qubit[{num_qubits}] {name};")
+
+    def declare_variable(self, name, symbol_type, value=None, const=False):
+        super().declare_variable(name, symbol_type, value, const)
+        prefix = "const " if const else ""
+        rhs = "" if self._is_default_initializer(value) else f" = {self._render_expression(value)}"
+        self._emit(f"{prefix}{self._render_type(symbol_type)} {name}{rhs};")
+
+    def update_value(self, variable, value):
+        super().update_value(variable, value)
+        self._emit(f"{self._render_expression(variable)} = {self._render_expression(value)};")
+
+    def _emit(self, line: str) -> None:
+        self._lines.append("    " * self._indent + line)
+
+    def _render_target(self, target) -> str:
+        # TODO: Add support for named registers in targets in AbstractProgramContext
+        return ", ".join(f"q[{q}]" for q in target)
+
+    @staticmethod
+    def _render_type(type_node) -> str:
+        match type_node:
+            case BoolType():
+                return "bool"
+            case BitType(size=size):
+                arr = "" if size is None else f"[{FlatProgramContext._render_expression(size)}]"
+                return f"bit{arr}"
+            case IntType(size=size):
+                arr = "" if size is None else f"[{FlatProgramContext._render_expression(size)}]"
+                return f"int{arr}"
+            case UintType(size=size):
+                arr = "" if size is None else f"[{FlatProgramContext._render_expression(size)}]"
+                return f"uint{arr}"
+            case FloatType(size=size):
+                arr = "" if size is None else f"[{FlatProgramContext._render_expression(size)}]"
+                return f"float{arr}"
+        raise NotImplementedError(f"Unsupported type {type_node!r}")
+
+    @staticmethod
+    def _render_expression(expr) -> str:
+        render = FlatProgramContext._render_expression
+        match expr:
+            case BooleanLiteral(value=value):
+                return "true" if value else "false"
+            case IntegerLiteral(value=value) | FloatLiteral(value=value):
+                return str(value)
+            case Identifier(name=name):
+                return name
+            case IndexedIdentifier(name=name, indices=indices):
+                return render(name) + "".join(
+                    ["[" + ", ".join(render(e) for e in group) + "]" for group in indices]
+                )
+            case IndexExpression(collection=collection, index=index):
+                return f"{render(collection)}[{', '.join(render(e) for e in index)}]"
+            case BinaryExpression(op=op, lhs=lhs, rhs=rhs):
+                return f"{render(lhs)} {op.name} {render(rhs)}"
+            case UnaryExpression(op=op, expression=inner):
+                return f"{op.name}{render(inner)}"
+            case ArrayLiteral(values=values):
+                return "{" + ", ".join(render(v) for v in values) + "}"
+            case RangeDefinition(start=start, end=end, step=step):
+                left = "" if start is None else render(start)
+                middle = ":" if step is None else f":{render(step)}:"
+                right = "" if end is None else render(end)
+                return f"[{left}{middle}{right}]"
+            case DiscreteSet(values=values):
+                return "{" + ", ".join(render(v) for v in values) + "}"
+        raise NotImplementedError(f"Unsupported expression {expr!r}")
+
+    @staticmethod
+    def _is_default_initializer(value) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, ArrayLiteral):
+            return all(FlatProgramContext._is_default_initializer(item) for item in value.values)
+        return False
 
 
 class TestAbstractContextControlFlow:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Properly makes expression MCM dependence determination implementation-independent by moving it from the concrete context class to a new abstract method called by the interpreter.

*Testing done:*

Verifies correct behavior with new tests backed by a context implementing dynamic circuit translation.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
