### PR TITLE
fix: Delegate branch calculation to correct simulator

### DIFF
--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -113,7 +113,12 @@ from .parser.openqasm_ast import (
     WhileLoop,
 )
 from .parser.openqasm_parser import parse
-from .program_context import AbstractProgramContext, ProgramContext, _BreakSignal, _ContinueSignal
+from .program_context import (
+    AbstractProgramContext,
+    ProgramContext,
+    _BreakSignal,
+    _ContinueSignal,
+)
 
 _EVALUABLE = (
     BooleanLiteral,

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -11,17 +11,18 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import fields
 from functools import singledispatchmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from sympy import Expr
 
 from braket.default_simulator.gate_operations import BRAKET_GATES, GPhase, Measure, Reset, Unitary
-from braket.default_simulator.linalg_utils import marginal_probability
 from braket.default_simulator.noise_operations import (
     AmplitudeDamping,
     BitFlip,
@@ -34,7 +35,6 @@ from braket.default_simulator.noise_operations import (
     TwoQubitDephasing,
     TwoQubitDepolarizing,
 )
-from braket.default_simulator.state_vector_simulation import StateVectorSimulation
 from braket.ir.jaqcd.program_v1 import Results
 
 from ._helpers.arrays import (
@@ -83,6 +83,9 @@ from .parser.openqasm_ast import (
     UnaryExpression,
 )
 from .simulation_path import FramedVariable, SimulationPath
+
+if TYPE_CHECKING:  # pragma: no cover
+    from braket.default_simulator.simulator import BaseLocalSimulator
 
 
 class Table:
@@ -412,10 +415,10 @@ class SubroutineTable(ScopedTable):
 
 class ScopeManager:
     """
-    Allows ProgramContext to manage scope with `with` keyword.
+    Allows AbstractProgramContext subclasses to manage scope with the `with` keyword.
     """
 
-    def __init__(self, context: "ProgramContext"):
+    def __init__(self, context: AbstractProgramContext):
         self.context = context
 
     def __enter__(self):
@@ -498,7 +501,7 @@ class AbstractProgramContext(ABC):
     def declare_variable(
         self,
         name: str,
-        symbol_type: ClassicalType | type[LiteralType] | type[Identifier],
+        symbol_type: type[LiteralType | Identifier] | ClassicalType,
         value: Any = None,
         const: bool = False,
     ) -> None:
@@ -1127,14 +1130,18 @@ class _ContinueSignal(Exception):
 
 
 class ProgramContext(AbstractProgramContext):
-    def __init__(self, circuit: Circuit | None = None):
+    def __init__(self, circuit: Circuit | None = None, simulator: BaseLocalSimulator | None = None):
         """
         Args:
             circuit (Circuit | None): A partially-built circuit to continue building with this
                 context. Default: None.
+            simulator (BaseLocalSimulator | None): The `BaseLocalSimulator` responsible for
+                computing measurement probabilities when branching occurs. Default: None, in which
+                case branching will raise at measurement time.
         """
         super().__init__()
         self._circuit = circuit or Circuit()
+        self._simulator = simulator
 
         # Path tracking for branched simulation (MCM support)
         self._paths: list[SimulationPath] = [SimulationPath()]
@@ -1183,7 +1190,7 @@ class ProgramContext(AbstractProgramContext):
     def declare_variable(
         self,
         name: str,
-        symbol_type: ClassicalType | type[LiteralType] | type[Identifier],
+        symbol_type: type[LiteralType | Identifier] | ClassicalType,
         value: Any = None,
         const: bool = False,
     ) -> None:
@@ -1979,18 +1986,17 @@ class ProgramContext(AbstractProgramContext):
             initial_path.set_variable(name, fv)
 
     def _measure_and_branch(self, target: tuple[int]) -> None:
-        """Compute measurement probabilities per active path, sample outcomes,
-        and branch paths with proportional shot allocation.
+        """Sample outcomes per active path and branch with proportional shot
+        allocation.
 
         For each qubit in target, for each active path:
-        1. Evolve the path's instructions through a fresh StateVectorSimulation
-           to get the current state vector.
-        2. Compute P(0) and P(1) for the measured qubit.
-        3. Sample `path.shots` outcomes from this distribution.
-        4. Split the path: one child gets shots that measured 0, the other gets
-           shots that measured 1.
-        5. If one outcome has 0 shots, don't create that branch (deterministic case).
-        6. Remove paths with 0 shots from the active set.
+        1. Ask the subclass-supplied ``_get_qubit_samples`` for
+           ``path.shots`` sampled bit outcomes of the qubit on this path.
+        2. Split the path: one child gets shots that measured 0, the other
+           gets shots that measured 1.
+        3. If one outcome has 0 shots, don't create that branch (deterministic
+           case).
+        4. Remove paths with 0 shots from the active set.
         """
         for qubit_idx in target:
             new_active_indices = []
@@ -2004,18 +2010,11 @@ class ProgramContext(AbstractProgramContext):
         """Branch a single path on a single qubit measurement."""
         path = self._paths[path_idx]
 
-        # Compute current state by evolving instructions through a fresh simulation
-        state = self._get_path_state(path)
-
-        # Get measurement probabilities for this qubit
-        probs = marginal_probability(np.abs(state) ** 2, targets=[qubit_idx])
-
-        # Sample outcomes
+        # Defer to the concrete simulator to sample the target qubit's bit for
+        # each of ``path.shots`` shots; then the shot-split is just a tally.
+        qubit_samples = self._get_qubit_samples(path, qubit_idx)
         path_shots = path.shots
-        rng = np.random.default_rng()
-        samples = rng.choice(len(probs), size=path_shots, p=probs)
-
-        shots_for_1 = int(np.sum(samples))
+        shots_for_1 = int(np.sum(qubit_samples))
         shots_for_0 = path_shots - shots_for_1
 
         if shots_for_1 == 0 or shots_for_0 == 0:
@@ -2053,7 +2052,13 @@ class ProgramContext(AbstractProgramContext):
         self._paths.append(new_path)
         new_active_indices.append(new_path_idx)
 
-    def _get_path_state(self, path: SimulationPath) -> np.ndarray:
+    def _get_qubit_samples(self, path: SimulationPath, qubit_idx: int) -> np.ndarray:
+        if self._simulator is None:
+            raise RuntimeError(
+                "ProgramContext has no simulator to sample measurement outcomes. "
+                "Construct it via ``BaseLocalSimulator.create_program_context`` or pass "
+                "``simulator=...`` to provide one."
+            )
         # Use the total declared qubit count (from the context), not just the
         # qubits that have appeared in instructions so far. This ensures that
         # measurements on qubits that haven't had gates applied yet still work
@@ -2061,13 +2066,12 @@ class ProgramContext(AbstractProgramContext):
         qubit_count = self.num_qubits
         if self._circuit.qubit_set:
             qubit_count = max(qubit_count, max(self._circuit.qubit_set) + 1)
-        sim = StateVectorSimulation(
-            qubit_count=qubit_count,
-            shots=path.shots,
-            batch_size=self._batch_size,
+        sim = self._simulator.initialize_simulation(
+            qubit_count=qubit_count, shots=path.shots, batch_size=self._batch_size
         )
         sim.evolve(path.instructions)
-        return sim.state_vector
+        samples = np.asarray(sim.retrieve_samples())
+        return (samples >> (qubit_count - 1 - qubit_idx)) & 1
 
 
 _BINARY_EQUALS = getattr(BinaryOperator, "==")

--- a/src/braket/default_simulator/simulator.py
+++ b/src/braket/default_simulator/simulator.py
@@ -22,7 +22,10 @@ import numpy as np
 from braket.default_simulator.observables import Hermitian, TensorProduct
 from braket.default_simulator.openqasm.circuit import Circuit
 from braket.default_simulator.openqasm.interpreter import Interpreter
-from braket.default_simulator.openqasm.program_context import AbstractProgramContext, ProgramContext
+from braket.default_simulator.openqasm.program_context import (
+    AbstractProgramContext,
+    ProgramContext,
+)
 from braket.default_simulator.operation import Observable, Operation
 from braket.default_simulator.operation_helpers import from_braket_instruction
 from braket.default_simulator.result_types import (
@@ -161,7 +164,7 @@ class BaseLocalSimulator(OpenQASMSimulator):
         return self.run_jaqcd(circuit_ir, *args, **kwargs)
 
     def create_program_context(self) -> AbstractProgramContext:
-        return ProgramContext()
+        return ProgramContext(simulator=self)
 
     @abstractmethod
     def initialize_simulation(self, **kwargs) -> Simulation:

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -4398,6 +4398,27 @@ class TestMCMFlushPendingEdgeCases:
         # Should not crash; measurement registered as normal circuit measurement
         assert ctx.circuit is not None
 
+    def test_branching_without_simulator_raises(self):
+        """A ``ProgramContext`` built without a simulator raises a clear error
+        if branching actually triggers a probability calculation."""
+        from braket.default_simulator.openqasm.interpreter import Interpreter
+        from braket.default_simulator.openqasm.program_context import ProgramContext
+
+        qasm = """
+        OPENQASM 3.0;
+        qubit[2] q;
+        bit b;
+        h q[0];
+        b = measure q[0];
+        if (b == 1) {
+            x q[1];
+        }
+        """
+        ctx = ProgramContext()
+        ctx._shots = 100  # force branching when the MCM-dependent ``if`` fires
+        with pytest.raises(RuntimeError, match="no simulator"):
+            Interpreter(ctx).run(qasm)
+
     def test_flush_when_already_branched(self, simulator):
         """Reading a pending MCM variable when already branched from an earlier MCM."""
         qasm = """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

RIght now, branch simulations are always done with `StateVectorSimulation`; we change this behavior to use the correct simulator implementation. With this, users will be able to plug in any backend to run dynamic circuits by subclassing `BaseLocalSimulator` and `Simulation`.

*Testing done:*

Added extra test for error on branch simulation with no provided simulator

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
