### PR TITLE
fix: shallow-copy circuit instructions into initial branched path

### DIFF
--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from copy import copy
 from dataclasses import fields
 from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Any
@@ -1970,7 +1971,7 @@ class ProgramContext(AbstractProgramContext):
         existing variables from the shared variable table to the path.
         """
         initial_path = self._paths[0]
-        initial_path._instructions = list(self._circuit.instructions)
+        initial_path._instructions = [copy(ins) for ins in self._circuit.instructions]
         initial_path.shots = self._shots
 
         for name, value in self.variable_table.items():

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3284,6 +3284,39 @@ class TestMCMAsymmetricMeasurement:
         assert counter == {"00": 1000}
 
 
+class TestMCMNonContiguousClassicalIndices:
+    """MCMs that write non-contiguous classical indices."""
+
+    def test_minimal_unassigned_low_bit_stays_zero(self, simulator):
+        """Untouched ``q[0]`` stays 0 when only ``c[1]`` is assigned."""
+        qasm = """
+        OPENQASM 3.0;
+        qubit[2] q;
+        bit[2] c;
+        h q[1];
+        c[1] = measure q[1];
+        if (c[1]) { x q[1]; }
+        """
+        result = simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=2000)
+        counter = Counter(["".join(m) for m in result.measurements])
+        assert counter == {"00": 2000}, f"Expected {{'00': 2000}}, got {dict(counter)}"
+
+    def test_if_branch_preserves_captured_bit_position(self, simulator):
+        """``if (c[N])`` keeps the captured value at ``q[N]``'s position."""
+        qasm = """
+        OPENQASM 3.0;
+        qubit[3] q;
+        bit[3] c;
+        h q[1];
+        c[1] = measure q[1];
+        if (c[1]) { x q[2]; }
+        c[2] = measure q[2];
+        """
+        result = simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=2000)
+        counter = Counter(["".join(m) for m in result.measurements])
+        assert set(counter) == {"000", "011"}, f"Expected {{'000', '011'}}, got {dict(counter)}"
+
+
 class TestMCMBranchedInstructionRouting:
     """Cover branched-mode instruction routing (add_*_instruction, add_measure, etc.)."""
 

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -3299,7 +3299,7 @@ class TestMCMNonContiguousClassicalIndices:
         """
         result = simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=2000)
         counter = Counter(["".join(m) for m in result.measurements])
-        assert counter == {"00": 2000}, f"Expected {{'00': 2000}}, got {dict(counter)}"
+        assert counter == {"00": 2000}
 
     def test_if_branch_preserves_captured_bit_position(self, simulator):
         """``if (c[N])`` keeps the captured value at ``q[N]``'s position."""
@@ -3314,7 +3314,7 @@ class TestMCMNonContiguousClassicalIndices:
         """
         result = simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=2000)
         counter = Counter(["".join(m) for m in result.measurements])
-        assert set(counter) == {"000", "011"}, f"Expected {{'000', '011'}}, got {dict(counter)}"
+        assert set(counter) == {"000", "011"}
 
 
 class TestMCMBranchedInstructionRouting:


### PR DESCRIPTION
*Issue #, if available:*
Fixes #370 

*Description of changes:*

The initial branched `SimulationPath` was seeded with shared references to `Circuit.instructions`, so the contiguous-qubit remapping in `BaseLocalSimulator._map_circuit_qubits` silently retargeted the path's gates and corrupted the final state whenever the circuit's qubit set was non-contiguous. Shallow-copying each instruction into the initial path keeps the two lists independent.

*Testing done:*

Added two regression tests in `TestMCMNonContiguousClassicalIndices` covering the minimal repro and the non-monotonic `c[N]` case; both fail on `main` and pass with the fix. All tests pass.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
