### PR TITLE
fix: Skip rvalue evaluation for MCM-dependent assignment

### DIFF
--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -597,6 +597,13 @@ class Interpreter:
         lvalue_name = get_identifier_name(node.lvalue)
         if self.context.get_const(lvalue_name):
             raise TypeError(f"Cannot update const value {lvalue_name}")
+        if (
+            self.context.supports_midcircuit_measurement
+            and not self.context.active_paths
+            and self.context.is_mcm_dependent(node.rvalue)
+        ):
+            self.context.track_mcm_dependency(lvalue_name, node.rvalue)
+            return
         rvalue = self.visit(
             node.rvalue
             if node.op == getattr(AssignmentOperator, "=")

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -4976,3 +4976,26 @@ class TestMCMDependencyTrackingOnAbstractContext:
             "}"
         )
         assert Interpreter(context=FlatProgramContext()).run(qasm).circuit == qasm
+
+    def test_flat_context_mcm_propagation_through_assignment(self):
+        """MCM dependency propagates through classical assignment without crashing.
+
+        When a measurement result is assigned to an intermediate variable and then
+        used in a condition, the interpreter should skip rvalue evaluation (since
+        non-simulating contexts have no runtime values) and just propagate the
+        MCM-dependency so the condition is correctly routed to evaluate_condition.
+        """
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "qubit[2] q;\n"
+            "bit mcm;\n"
+            "bit tmp;\n"
+            "tmp = measure q[0];\n"
+            "mcm = tmp;\n"
+            "if (mcm == 1) {\n"
+            "    x q[1];\n"
+            "}"
+        )
+        result = Interpreter(context=FlatProgramContext()).run(qasm).circuit
+        assert "if (mcm == 1)" in result
+        assert "x q[1]" in result


### PR DESCRIPTION
When a classical assignment has an MCM-dependent rvalue and the context has no active simulation paths (e.g., Qiskit circuit-building contexts), skip evaluating the rvalue and just propagate MCM-dependency. This prevents NameError when measurement results have no stored runtime value.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
