### PR TITLE
deprecation: warn on JaqcdProgram submission to local simulators (MCM-150287739)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,11 @@ env=
 addopts =
     --verbose -n logical --durations=0 --durations-min=0.5
 testpaths = test/unit_tests
+filterwarnings =
+    # Many existing tests deliberately exercise the JaqcdProgram code path
+    # (e.g. parametrized tests that compare JAQCD vs OpenQASM behavior). The
+    # JAQCD deprecation warning is expected on those paths; ignore it here.
+    # Tests that specifically assert the warning fires use
+    # `pytest.warns(UserWarning, match="JaqcdProgram")` directly and are
+    # unaffected by this filter.
+    ignore:Submitting JaqcdProgram to LocalSimulator is deprecated:UserWarning

--- a/src/braket/default_simulator/simulator.py
+++ b/src/braket/default_simulator/simulator.py
@@ -138,6 +138,15 @@ class BaseLocalSimulator(OpenQASMSimulator):
         """
         Simulate a program using either OpenQASM or Jaqcd.
 
+        .. deprecated:: 1.39.4
+            Submitting a ``JaqcdProgram`` to a local simulator is deprecated
+            and emits a ``UserWarning``. Submit an ``OpenQASMProgram`` (or a
+            ``ProgramSet``) instead. Amazon Braket service devices no longer
+            accept JAQCD program submissions; see MCM-150287739. Local
+            simulators continue to accept JAQCD programs in this release so
+            historical notebooks keep working during the migration window;
+            JAQCD support will be removed in a future release.
+
         Args:
             circuit_ir (OpenQASMProgram | ProgramSet | JaqcdProgram): Program
                 specification.
@@ -161,6 +170,14 @@ class BaseLocalSimulator(OpenQASMSimulator):
             return self.run_openqasm(circuit_ir, *args, **kwargs)
         elif isinstance(circuit_ir, ProgramSet):
             return self.run_program_set(circuit_ir, *args, **kwargs)
+        if isinstance(circuit_ir, JaqcdProgram):
+            warnings.warn(
+                "Submitting JaqcdProgram to LocalSimulator is deprecated and "
+                "will be removed in a future release. Submit OpenQASMProgram "
+                "instead. Amazon Braket service devices no longer accept "
+                "JAQCD program submissions. See MCM-150287739.",
+                stacklevel=2,
+            )
         return self.run_jaqcd(circuit_ir, *args, **kwargs)
 
     def create_program_context(self) -> AbstractProgramContext:

--- a/test/unit_tests/braket/default_simulator/test_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_simulator.py
@@ -11,12 +11,18 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import json
+import warnings
+
 import numpy as np
 import pytest
+from braket.ir.jaqcd import Program as JaqcdProgram
+from braket.ir.openqasm import Program as OpenQASMProgram
 
 from braket.default_simulator import observables
 from braket.default_simulator.result_types import DensityMatrix, Expectation, Probability, Variance
 from braket.default_simulator.simulator import BaseLocalSimulator
+from braket.default_simulator.state_vector_simulator import StateVectorSimulator
 
 
 @pytest.mark.parametrize(
@@ -60,3 +66,50 @@ def test_observable_hash_tensor_product():
 def test_base_local_simulator_abstract():
     with pytest.raises(TypeError, match="Can't instantiate abstract class BaseLocalSimulator"):
         BaseLocalSimulator()
+
+
+def _minimal_jaqcd_program() -> JaqcdProgram:
+    """Build a minimal JaqcdProgram for warning-assertion tests."""
+    return JaqcdProgram.parse_raw(
+        json.dumps(
+            {
+                "instructions": [{"type": "h", "target": 0}],
+                "results": [{"type": "probability", "targets": [0]}],
+            }
+        )
+    )
+
+
+def _minimal_openqasm_program() -> OpenQASMProgram:
+    """Build a minimal OpenQASMProgram for warning-assertion tests."""
+    return OpenQASMProgram(
+        source="""
+        qubit q;
+        h q;
+        #pragma braket result probability q
+        """
+    )
+
+
+def test_run_jaqcd_emits_warning():
+    """Submitting a JaqcdProgram via BaseLocalSimulator.run should emit a
+    UserWarning telling the customer to migrate to OpenQASMProgram. The
+    program still executes — this is a soft deprecation."""
+    simulator = StateVectorSimulator()
+    with pytest.warns(UserWarning, match="JaqcdProgram"):
+        result = simulator.run(_minimal_jaqcd_program(), qubit_count=1, shots=10)
+    assert result is not None
+
+
+def test_run_openqasm_no_jaqcd_warning():
+    """The OpenQASM path must not emit the JAQCD deprecation warning. Assert
+    specifically on JAQCD-message warnings rather than erroring on all
+    UserWarnings, since other unrelated warnings (e.g. the density-matrix
+    noise advisory) are legitimate."""
+    simulator = StateVectorSimulator()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = simulator.run(_minimal_openqasm_program(), shots=10)
+    jaqcd_warnings = [x for x in w if "JaqcdProgram" in str(x.message)]
+    assert jaqcd_warnings == []
+    assert result is not None


### PR DESCRIPTION
## Issue, if available

Internal: MCM-150287739 (Simulators broker migration removes JAQCD from Braket service device capabilities).

Coordinated deprecation across three Braket OSS Python packages:
- amazon-braket-schemas-python: https://github.com/amazon-braket/amazon-braket-schemas-python/pull/221
- amazon-braket-sdk-python: https://github.com/amazon-braket/amazon-braket-sdk-python/pull/1262
- **amazon-braket-default-simulator-python: this PR**

## Description of changes

Amazon Braket service devices no longer accept JAQCD program submissions. `LocalSimulator` is offline (it doesn't depend on the service) so it can keep accepting JAQCD programs through the migration window — but it now emits a `UserWarning` telling customers to migrate to `OpenQASMProgram`. JAQCD support will be removed in a follow-up CR after a release cycle of warnings.

### Code changes

- `src/braket/default_simulator/simulator.py`:
  - In `BaseLocalSimulator.run()`, add an `isinstance(circuit_ir, JaqcdProgram)` branch before the fallthrough to `run_jaqcd` that emits a `UserWarning` referencing MCM-150287739.
  - Added a `.. deprecated:: 1.39.4` Sphinx directive to the `run()` docstring.
- `setup.cfg`: added a pytest `filterwarnings` rule that ignores the new JAQCD warning during the test session — see "Why a session-level filter?" below.

### What is intentionally NOT changed

- `run_jaqcd()` and the JAQCD execution path remain fully functional. Customer code submitting JAQCD continues to run; only the warning is new.
- `state_vector_simulator.py` and `density_matrix_simulator.py` `properties.action[\"braket.ir.jaqcd.program\"]` blocks are preserved. Cached capability documents on customer machines continue to deserialize correctly through `amazon-braket-schemas`. The hard-removal CR will revisit these.

### Why a session-level filter (not per-test wraps)

Many existing parametrized tests deliberately exercise the JAQCD code path (e.g. `test_simulator_run_grcs_8[Jaqcd]`, `test_simulator_run_no_results_no_shots`, etc.) — wrapping each call site in `pytest.warns(UserWarning)` would create churn across multiple files and risks missing a call site.

Instead, `setup.cfg` adds:

```
[tool:pytest]
filterwarnings =
    ignore:Submitting JaqcdProgram to LocalSimulator is deprecated:UserWarning
```

This silences only this specific warning message in the test session. The new positive-assertion test (`test_run_jaqcd_emits_warning`) uses `pytest.warns()` which overrides this filter, so the warning contract is still verified.

### Why ``UserWarning`` and not ``DeprecationWarning``

`DeprecationWarning` is suppressed by default (PEP 565) for any warning attributed outside `__main__`. That hides it from customer code that wraps Braket calls in helper functions or libraries — exactly the cases we need to reach. `UserWarning` is visible by default and matches the existing `warnings.warn` call site in this package (e.g. the `qubit_count is deprecated` warning at `simulator.py:949`, which also uses `UserWarning`).

## Testing done

```
tox -e unit-tests   # 1167 passed, 72 xfailed, 120 warnings, 0 leaked JAQCD warnings
tox -e linters      # ruff format + ruff check, all clean
```

New tests in `test/unit_tests/braket/default_simulator/test_simulator.py`:
- `test_run_jaqcd_emits_warning` — positive assertion using `pytest.warns(UserWarning, match=\"JaqcdProgram\")`.
- `test_run_openqasm_no_jaqcd_warning` — negative assertion that the OpenQASM path stays silent (filters by message rather than erroring on all `UserWarning` so unrelated warnings like the density-matrix noise advisory don't false-fail).

Manual verification (visible-by-default warning, runs successfully):

```python
import json
from braket.ir.jaqcd import Program as JaqcdProgram
from braket.default_simulator.state_vector_simulator import StateVectorSimulator

sim = StateVectorSimulator()
jaqcd = JaqcdProgram.parse_raw(json.dumps({
    'instructions': [{'type':'h','target':0}],
    'results': [{'type':'probability','targets':[0]}],
}))
sim.run(jaqcd, qubit_count=1, shots=10)
# stderr: <string>:10: UserWarning: Submitting JaqcdProgram to LocalSimulator
# is deprecated and will be removed in a future release. Submit
# OpenQASMProgram instead. ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.