### PR TITLE
fix: inner-scope shadowing during branched identifier lookup

### DIFF
--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -1258,6 +1258,9 @@ class ProgramContext(AbstractProgramContext):
             return super().get_value_by_identifier(identifier)
 
         name = get_identifier_name(identifier)
+        if self._bound_in_inner_scope(name):
+            return super().get_value_by_identifier(identifier)
+
         path = self._paths[self._active_path_indices[0]]
         framed_var = path.get_variable(name)
         if framed_var is None:
@@ -1285,6 +1288,9 @@ class ProgramContext(AbstractProgramContext):
         if not self._is_branched:
             return super().is_initialized(name)
 
+        if self._bound_in_inner_scope(name):
+            return super().is_initialized(name)
+
         # Check per-path variables first
         path = self._paths[self._active_path_indices[0]]
         framed_var = path.get_variable(name)
@@ -1293,6 +1299,10 @@ class ProgramContext(AbstractProgramContext):
 
         # Fall back to shared variable table
         return super().is_initialized(name)
+
+    def _bound_in_inner_scope(self, name: str) -> bool:
+        """Whether ``name`` is bound in a non-global variable-table scope."""
+        return any(name in scope for scope in self.variable_table._scopes[1:])
 
     def _flush_pending_mcm_for_variable(self, name: str) -> None:
         """If ``name`` matches a pending MCM's classical destination, flush it.

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -1258,14 +1258,12 @@ class ProgramContext(AbstractProgramContext):
             return super().get_value_by_identifier(identifier)
 
         name = get_identifier_name(identifier)
-        if self._bound_in_inner_scope(name):
-            return super().get_value_by_identifier(identifier)
-
         path = self._paths[self._active_path_indices[0]]
         framed_var = path.get_variable(name)
-        if framed_var is None:
-            # Fall back to the shared variable table for variables declared
-            # before branching started
+        # Fall back to the shared variable table for variables declared before
+        # branching started and for identifiers shadowed by an inner scope
+        # (e.g. gate-expansion qubit aliases).
+        if framed_var is None or self._bound_in_inner_scope(name):
             return super().get_value_by_identifier(identifier)
 
         value = framed_var.value
@@ -1288,16 +1286,13 @@ class ProgramContext(AbstractProgramContext):
         if not self._is_branched:
             return super().is_initialized(name)
 
-        if self._bound_in_inner_scope(name):
-            return super().is_initialized(name)
-
-        # Check per-path variables first
+        # Inner-scope bindings (e.g. gate-expansion qubit aliases) shadow the
+        # per-path outer variable of the same name; defer to the scoped
+        # variable-table lookup in super.
         path = self._paths[self._active_path_indices[0]]
         framed_var = path.get_variable(name)
-        if framed_var is not None:
+        if framed_var is not None and not self._bound_in_inner_scope(name):
             return True
-
-        # Fall back to shared variable table
         return super().is_initialized(name)
 
     def _bound_in_inner_scope(self, name: str) -> bool:

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -5196,3 +5196,24 @@ class TestDensityMatrixSimulatorBranching:
         # Mirrors a verbatim ``measure_ff(q[13], 0); cc_prx(q[17], pi, 0, 0)``
         # emission: q[17] flips iff b[0]==1 → outcomes "00" and "11" each ~50%.
         self._assert_distributions_match(qasm, expected_keys={"00", "11"})
+
+
+class TestBranchedInnerScopeShadowing:
+    """Inner-scope bindings (e.g. qubit aliases from `declare_qubit_alias`)
+    must shadow outer-scope per-path classical variables of the same name."""
+
+    def test_qubit_alias_shadows_outer_classical_variable(self):
+        # `rx`'s qubit parameter is `a`; the outer `float a` must not leak
+        # into the gate body's identifier resolution when branched.
+        qasm = """
+        OPENQASM 3;
+        gate rx(theta) a { U(theta, -1.5707963267948966, 1.5707963267948966) a; }
+        qubit[1] q;
+        bit c;
+        float a = 3.14159265;
+        c = measure q[0];
+        if (c == false) { }
+        rx(a) q[0];
+        """
+        result = StateVectorSimulator().run(OpenQASMProgram(source=qasm), shots=10)
+        assert len(result.measurements) == 10


### PR DESCRIPTION
*Issue #, if available:*

Fixes #386.

*Description of changes:*
The branched-mode overrides of `get_value_by_identifier` and `is_initialized` consult the per-path variable table before the scope-aware `variable_table`. When a user-defined gate expansion declares a qubit alias (e.g. `rx`'s parameter `a`) whose name matches an outer-scope classical variable, that outer variable lives in the flat per-path dict and shadows the inner qubit alias, crashing on the next `get_qubit_size` call with `'FloatLiteral' object has no attribute 'name'`.

Defer to the superclass path whenever the identifier is bound in a non-global `variable_table` scope so inner-scope bindings win, matching the non-branched execution semantics.

*Testing done:*

tox passes. Test added which reproduced existing bug, now passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
