### PR TITLE
fix: resolve measurement destination index before branching

### DIFF
--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -1888,11 +1888,6 @@ class ProgramContext(AbstractProgramContext):
             path.exit_frame(path.frame_number - 1)
 
     @staticmethod
-    def _resolve_index(indices) -> int:
-        """Resolve the integer index from an IndexedIdentifier's index list."""
-        return indices[0][0].value
-
-    @staticmethod
     def _get_path_measurement_result(path: SimulationPath, qubit_idx: int) -> int:
         """Get the most recent measurement outcome for a qubit on a path."""
         return path.measurements[qubit_idx][-1]
@@ -1911,7 +1906,9 @@ class ProgramContext(AbstractProgramContext):
         """Get the FramedVariable for ``name`` on the given path."""
         return path.get_variable(name)
 
-    def _update_classical_from_measurement(self, qubit_target, classical_destination) -> None:
+    def _update_classical_from_measurement(
+        self, qubit_target, classical_destination, classical_targets=None
+    ) -> None:
         """Update classical variables per path with measurement outcomes.
 
         After _measure_and_branch has branched paths and recorded measurement
@@ -1928,26 +1925,33 @@ class ProgramContext(AbstractProgramContext):
             path = self._paths[path_idx]
 
             if isinstance(classical_destination, IndexedIdentifier):
-                self._update_indexed_target(path, qubit_target, classical_destination)
+                self._update_indexed_target(
+                    path, qubit_target, classical_destination, classical_targets
+                )
             else:
                 self._update_identifier_target(path, qubit_target, classical_destination)
 
     def _update_indexed_target(
-        self, path: SimulationPath, qubit_target, classical_destination: IndexedIdentifier
+        self,
+        path: SimulationPath,
+        qubit_target,
+        classical_destination: IndexedIdentifier,
+        classical_targets: Iterable[int],
     ) -> None:
-        """Update a single indexed classical variable on one path.
+        """Update an indexed classical variable on one path.
 
-        Handles the ``b[i] = measure q[j]`` case.
+        Handles the ``b[i] = measure q[j]`` case. ``classical_targets`` holds the destination
+        indices already resolved by the interpreter, one per measured qubit.
         """
         base_name = (
             classical_destination.name.name
             if hasattr(classical_destination.name, "name")
             else classical_destination.name
         )
-        index = self._resolve_index(classical_destination.indices)
-        meas_result = self._get_path_measurement_result(path, qubit_target[0])
         framed_var = self._ensure_path_variable(path, base_name)
-        self._set_value_at_index(framed_var.value, index, meas_result)
+        for qubit_idx, index in zip(qubit_target, classical_targets):
+            meas_result = self._get_path_measurement_result(path, qubit_idx)
+            self._set_value_at_index(framed_var.value, index, meas_result)
 
     def _update_identifier_target(
         self, path: SimulationPath, qubit_target, classical_destination: Identifier
@@ -1992,7 +1996,7 @@ class ProgramContext(AbstractProgramContext):
         classical_destination,
     ) -> None:
         self._measure_and_branch(target)
-        self._update_classical_from_measurement(target, classical_destination)
+        self._update_classical_from_measurement(target, classical_destination, classical_targets)
         if classical_targets is not None:
             self._circuit.add_measure(
                 target,

--- a/test/unit_tests/braket/default_simulator/test_mcm.py
+++ b/test/unit_tests/braket/default_simulator/test_mcm.py
@@ -353,9 +353,6 @@ class TestStateVectorSimulatorOperatorsOpenQASM:
 
         assert len(result.measurements) == 1000
 
-    @pytest.mark.xfail(
-        reason="Interpreter gap: branched condition BinaryExpression not fully resolved"
-    )
     def test_5_2_for_loop_operations_with_branching(self):
         """5.2 For loop operations - using execute_with_branching to test variables"""
         qasm_source = """
@@ -2788,6 +2785,77 @@ class TestUnifiedMCMClassicalVariables:
         # If b==1: x becomes 1, flip q[1] -> |11>
         assert set(counter.keys()) == {"00", "11"}
         assert 0.4 < counter["00"] / 1000 < 0.6
+
+    @pytest.mark.parametrize(
+        "declaration, destination",
+        [
+            ("", "b[0]"),
+            ("const int k = 0;", "b[k]"),
+            ("int k = 0;", "b[k]"),
+        ],
+    )
+    def test_branched_measurement_into_indexed_destination(
+        self, simulator, declaration, destination
+    ):
+        """A measurement destination index may be any expression the interpreter resolves,
+        not only a literal. Branching must use the resolved index."""
+        qasm = f"""
+        OPENQASM 3.0;
+        qubit[2] q;
+        bit[2] b;
+        {declaration}
+
+        x q[0];
+        {destination} = measure q[0];
+
+        if (b[0] == 1) {{
+            x q[1];
+        }}
+        b[1] = measure q[1];
+        """
+        result = simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=10)
+        # q[0] is deterministically |1>, so the branch always fires and flips q[1].
+        assert Counter(["".join(m) for m in result.measurements]) == Counter({"11": 10})
+
+    def test_branched_measurement_into_loop_variable_index(self, simulator):
+        """The loop variable is out of scope once branching replays a deferred measurement,
+        so the destination index has to have been resolved before the loop exits."""
+        qasm = """
+        OPENQASM 3.0;
+        qubit[2] q;
+        bit[2] b;
+
+        x q[0];
+        for int i in [0:0] {
+            b[i] = measure q[i];
+        }
+
+        if (b[0] == 1) {
+            x q[1];
+        }
+        b[1] = measure q[1];
+        """
+        result = simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=10)
+        assert Counter(["".join(m) for m in result.measurements]) == Counter({"11": 10})
+
+    def test_branched_measurement_into_range_destination(self, simulator):
+        """A range destination writes one bit per measured qubit."""
+        qasm = """
+        OPENQASM 3.0;
+        qubit[3] q;
+        bit[3] b;
+
+        x q[0];
+        b[0:1] = measure q[0:1];
+
+        if (b[0] == 1) {
+            x q[2];
+        }
+        b[2] = measure q[2];
+        """
+        result = simulator.run_openqasm(OpenQASMProgram(source=qasm, inputs={}), shots=10)
+        # q[0]=1 and q[1]=0 are written through the range; the branch then flips q[2].
+        assert Counter(["".join(m) for m in result.measurements]) == Counter({"101": 10})
 
 
 class TestUnifiedMCMEdgeCases:


### PR DESCRIPTION
*Issue #, if available:*

Fixes #390.

*Description of changes:*

`b[i] = measure q[j]` crashes with `AttributeError: 'Identifier' object has no attribute 'value'` once a later condition promotes the deferred measurement to branched execution. A literal index works; `const`, identifier and range destinations do not.

**The index is already resolved before it is needed. It is then dropped, and recomputed by reading `.value` off the raw AST node — which only an `IntegerLiteral` has.**

```
interpreter.py           resolves node.target.indices, passes it as classical_targets  <- correct value
_branch_measurement      receives it, uses it correctly for _circuit.add_measure(...)
                         └─ does not forward it to _update_classical_from_measurement  <- dropped here
_update_indexed_target   re-derives the index from the raw AST
_resolve_index           indices[0][0].value   <- Identifier has .name, not .value  -> crash
```

This is not a scoping problem: `const int k = 0` is still perfectly in scope when the crash happens — it is simply never looked up. `_resolve_index` reads the attribute straight off the node.

Resolving it lazily at replay time would not be a general fix either, though:

| destination index | resolvable when the measurement is replayed? |
| --- | --- |
| `const int k = 0` | yes |
| `for` loop variable `i` | no — `KeyError: 'Undefined key: i'`, the loop has exited |

So the fix is to forward `classical_targets` and use it. That is what the non-branched path already does: `_flush_pending_mcm_targets` discards the destination (`_mcm_dest`) and uses the resolved indices. This makes branched execution agree with non-branched execution.

Zipping the resolved indices with the measured qubits also fixes range destinations (`b[0:1] = measure q[0:1]`), previously `'RangeDefinition' object has no attribute 'value'`. `_resolve_index` had no other caller and is removed.

Why this is safe: `_update_indexed_target` is only reached when the destination is an `IndexedIdentifier`, and `interpreter.py` always populates `classical_targets` in that case. The one caller that passes a destination without targets — `_handle_measure_ff` — uses a plain `Identifier`, which routes to `_update_identifier_target` instead.

*Testing done:*

`tox` passes — 1188 unit tests, linters clean.

Branched execution now matches non-branched:

| destination | non-branched | branched, before | branched, after |
| --- | --- | --- | --- |
| `r[0]` literal | `'1'` | `'1'` | `'1'` |
| `r[k]`, `const int k = 0` | `'1'` | crash | `'1'` |
| `r[i]`, `for int i in [0:1]` | `'10'` | crash | `'10'` |
| `r[0:1] = measure q` | `'10'` | crash | `'10'` |

Added `test_branched_measurement_into_indexed_destination` (literal / `const` / non-`const` identifier), `test_branched_measurement_into_loop_variable_index` and `test_branched_measurement_into_range_destination`. Four of the five fail against the unpatched source; the literal row is the regression guard and passes either way.

Feed-forward works end to end rather than merely not crashing: with the branch made deterministic, `r[k] = measure q[0]; if (r[0] == true) { x q[1]; }` gives `{'11': 10}`.

Also removes the `xfail` from `test_5_2_for_loop_operations_with_branching` ("Interpreter gap: branched condition BinaryExpression not fully resolved"), which this fixes.

Out of scope: `r[1-1] = measure q[0]` fails on the branched *and* non-branched paths, because `interpreter.py` never evaluates a destination index that is a `BinaryExpression`. That is a separate gap, and the two paths agree there.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
