### PR TITLE
fix: cap static while-loop unrolling to prevent infinite loops

### DIFF
--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -135,6 +135,9 @@ _EVALUABLE = (
 )
 
 
+_MAX_LOOP_ITERATIONS = 100_000
+
+
 class Interpreter:
     """
     The interpreter is responsible for visiting the AST of an OpenQASM program, as created
@@ -712,7 +715,14 @@ class Interpreter:
                     self.context.handle_loop_continue()
                     continue
         else:
+            iterations = 0
             while cast_to(BooleanLiteral, self.visit(node.while_condition)).value:
+                iterations += 1
+                if _MAX_LOOP_ITERATIONS > 0 and iterations > _MAX_LOOP_ITERATIONS:
+                    raise RuntimeError(
+                        f"While loop exceeded {_MAX_LOOP_ITERATIONS} iterations "
+                        f"during static unrolling. The loop condition may never become false."
+                    )
                 try:
                     self.visit(deepcopy(node.block))
                 except _BreakSignal:

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -45,6 +45,7 @@ from braket.default_simulator.openqasm._helpers.casting import (
     convert_string_to_bool_array,
 )
 from braket.default_simulator.openqasm.circuit import Circuit
+from braket.default_simulator.openqasm import interpreter as interp_module
 from braket.default_simulator.openqasm.interpreter import Interpreter
 from braket.default_simulator.openqasm.parser.openqasm_ast import (
     AliasStatement,
@@ -2724,3 +2725,42 @@ def test_undefined_function_in_branching_condition():
     """
     with pytest.raises(NameError, match="Subroutine undefined_func is not defined"):
         Interpreter().run(qasm)
+
+
+def test_infinite_while_loop_raises(monkeypatch):
+    """Static while loop that never terminates raises RuntimeError."""
+    monkeypatch.setattr(interp_module, "_MAX_LOOP_ITERATIONS", 10)
+    qasm = """
+    int[8] x = 1;
+    while (x > 0) {
+        x += 1;
+    }
+    """
+    with pytest.raises(RuntimeError, match="While loop exceeded .* iterations"):
+        Interpreter().run(qasm)
+
+
+def test_while_loop_within_limit_succeeds(monkeypatch):
+    """Static while loop that terminates within the limit works normally."""
+    monkeypatch.setattr(interp_module, "_MAX_LOOP_ITERATIONS", 10)
+    qasm = """
+    int[8] i = 0;
+    while (i < 5) {
+        i += 1;
+    }
+    """
+    context = Interpreter().run(qasm)
+    assert context.get_value("i") == IntegerLiteral(5)
+
+
+def test_while_loop_no_limit_when_constant_is_zero(monkeypatch):
+    """Setting _MAX_LOOP_ITERATIONS to 0 disables the iteration limit."""
+    monkeypatch.setattr(interp_module, "_MAX_LOOP_ITERATIONS", 0)
+    qasm = """
+    int[8] i = 0;
+    while (i < 20) {
+        i += 1;
+    }
+    """
+    context = Interpreter().run(qasm)
+    assert context.get_value("i") == IntegerLiteral(20)


### PR DESCRIPTION
## Summary
  
  Adds a safety cap on static while-loop unrolling in the OpenQASM interpreter to prevent infinite loops from hanging the process.
  
  ## Problem
  
  When the interpreter encounters a `while` loop whose condition is not dependent on a mid-circuit measurement, it statically unrolls the loop by repeatedly evaluating the condition and visiting the body.
  If the condition never becomes false (e.g., `while (x > 0) { x += 1; }`), this hangs forever with no way to recover.
  
  ## Fix
  
  Add a module-level constant `_MAX_LOOP_ITERATIONS = 100_000` that caps the number of iterations in the static unrolling path. If exceeded, a `RuntimeError` is raised with a clear message.
  
  The MCM path (mid-circuit measurement dependent condition) is unaffected — it generates a `WhileLoopOp` without unrolling and needs no limit.
  
  Setting `_MAX_LOOP_ITERATIONS` to `<= 0` disables the limit.
  
  ## Changes
  
  - **`interpreter.py`**: Added `_MAX_LOOP_ITERATIONS` constant and iteration counter in the static while-loop `else` branch.
  - **`test_interpreter.py`**: Added 3 tests:
    - Infinite loop raises `RuntimeError` when limit is exceeded
    - Loop within limit succeeds normally
    - Setting limit to 0 disables enforcement
  
  ## Testing
  
  - 135 interpreter tests pass
  - 1188 total unit tests pass
  - No regressions
  
  ## Merge Checklist
  
  - [x] I have added tests that prove my fix is effective
  - [x] Tests are not configured for a specific region or account
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
