### PR TITLE
fix: broadcast bare-register operand observable

### DIFF
--- a/src/braket/default_simulator/openqasm/parser/braket_pragmas.py
+++ b/src/braket/default_simulator/openqasm/parser/braket_pragmas.py
@@ -100,12 +100,14 @@ class BraketPragmaNodeVisitor(BraketPragmasParserVisitor):
     def visitStandardObservableIdentifier(
         self,
         ctx: BraketPragmasParser.StandardObservableIdentifierContext,
-    ) -> tuple[tuple[str], int]:
+    ) -> tuple[tuple[str], tuple[int] | None]:
         observable = ctx.standardObservableName().getText()
         target_tuple = self.visit(ctx.gateOperand())
-        if len(target_tuple) != 1:
-            raise ValueError("Standard observable target must be exactly 1 qubit.")
-        return (observable,), target_tuple
+        if len(target_tuple) == 1:
+            return (observable,), target_tuple
+        # Bare register operand (e.g. `expectation h(q)` with `qubit[N] q;`)
+        # broadcasts across the register, same as `h q;` / `barrier q;`.
+        return (observable,), None
 
     def visitStandardObservableAll(
         self,

--- a/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
@@ -603,18 +603,32 @@ def test_result_types_analytic():
     assert np.allclose(result_types[17].value, 0)
 
 
-def test_invalid_standard_observable_target():
+def test_standard_observable_broadcast_over_register():
     qasm = """
     qubit[2] qs;
+    i qs;
     #pragma braket result variance x(qs)
     """
     simulator = StateVectorSimulator()
-    program = OpenQASMProgram(source=qasm)
+    result = simulator.run(OpenQASMProgram(source=qasm), shots=0)
 
-    must_be_one_qubit = "Standard observable target must be exactly 1 qubit."
+    assert len(result.resultTypes) == 1
+    assert result.resultTypes[0].type == Variance(observable=["x"], targets=None)
+    assert np.allclose(result.resultTypes[0].value, [1.0, 1.0])
 
-    with pytest.raises(ValueError, match=must_be_one_qubit):
-        simulator.run(program, shots=0)
+
+def test_standard_observable_broadcast_over_register_end_to_end():
+    qasm = """
+    qubit[2] q;
+    h q;
+    #pragma braket result expectation h(q)
+    """
+    simulator = StateVectorSimulator()
+    result = simulator.run(OpenQASMProgram(source=qasm), shots=0)
+
+    assert len(result.resultTypes) == 1
+    assert result.resultTypes[0].type == Expectation(observable=["h"], targets=None)
+    assert np.allclose(result.resultTypes[0].value, [1 / np.sqrt(2), 1 / np.sqrt(2)])
 
 
 @pytest.mark.parametrize("shots", (0, 10))


### PR DESCRIPTION
Description of changes:
  
  `#pragma braket result expectation h(q)` with a bare qubit register q used to raise Standard observable target must be exactly 1 qubit. It now broadcasts across the register, the same way `h q; and barrier q;` do in OpenQASM 3.
  
  Change is one-line semantic: `visitStandardObservableIdentifier returns ((observable,), None)` when the operand resolves to more than one qubit, matching what `visitStandardObservableAll` returns. Downstream ObservableResultType.calculate then produces one result per qubit.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
