### PR TITLE
fix: route pragma HardwareQubit references through qubit_table

### DIFF
--- a/src/braket/default_simulator/openqasm/parser/braket_pragmas.py
+++ b/src/braket/default_simulator/openqasm/parser/braket_pragmas.py
@@ -28,6 +28,7 @@ from braket.ir.jaqcd.program_v1 import Results
 from .generated.BraketPragmasLexer import BraketPragmasLexer
 from .generated.BraketPragmasParser import BraketPragmasParser
 from .generated.BraketPragmasParserVisitor import BraketPragmasParserVisitor
+from .openqasm_ast import Identifier
 from .openqasm_parser import parse
 
 
@@ -136,9 +137,17 @@ class BraketPragmaNodeVisitor(BraketPragmasParserVisitor):
         return (converted,), target
 
     def visitGateOperand(self, ctx: BraketPragmasParser.GateOperandContext) -> tuple[int]:
-        """Handle both indexedIdentifier (q[0]) and HardwareQubit ($0) in pragmas."""
+        """Handle both indexedIdentifier (q[0]) and HardwareQubit ($0) in pragmas.
+
+        Both branches delegate to ``qubit_table.get_by_identifier`` so context
+        subclasses can translate qubit references (e.g. mapping device labels
+        to interpreter indices for consumers that carry a topology-aware
+        physical-qubit map). The default ``QubitTable`` treats ``$N`` as
+        ``(N,)`` so behavior is unchanged for callers using the base table.
+        """
         if ctx.HardwareQubit():
-            return (int(ctx.HardwareQubit().getText()[1:]),)
+            identifier = Identifier(name=ctx.HardwareQubit().getText())
+            return self.qubit_table.get_by_identifier(identifier)
         return self.visit(ctx.indexedIdentifier())
 
     def visitIndexedIdentifier(

--- a/test/unit_tests/braket/default_simulator/openqasm/test_braket_pragmas.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_braket_pragmas.py
@@ -1,0 +1,97 @@
+"""Unit tests for braket pragma parsing.
+
+Regression tests for the routing of ``$N`` (HardwareQubit) references through
+``QubitTable.get_by_identifier`` in ``visitGateOperand``. This ensures every
+pragma path (multi-target, standard observable, tensor-product observable) is
+subclass-observable so custom contexts can translate device labels.
+"""
+
+import pytest
+
+from braket.default_simulator.openqasm.parser.braket_pragmas import parse_braket_pragma
+from braket.default_simulator.openqasm.program_context import QubitTable
+from braket.ir.jaqcd import (
+    DensityMatrix,
+    Expectation,
+    Probability,
+    Sample,
+    Variance,
+)
+
+
+class _OffsetQubitTable(QubitTable):
+    """QubitTable subclass that shifts ``$N`` references by a fixed offset.
+
+    Concretely emulates the way a consumer (qbp) translates device labels to
+    interpreter indices: the resolved value must differ from the raw label so
+    that the tests fail if ``$N`` bypasses ``get_by_identifier`` and gets
+    resolved by a text-hack in the visitor.
+    """
+
+    _OFFSET = 100
+
+    def get_by_identifier(self, identifier):
+        indices = super().get_by_identifier(identifier)
+        name = getattr(identifier, "name", None)
+        if isinstance(name, str) and name.startswith("$"):
+            return tuple(i + self._OFFSET for i in indices)
+        return indices
+
+
+@pytest.mark.parametrize(
+    ("pragma_body", "result_type", "expected_targets"),
+    [
+        pytest.param(
+            "braket result expectation z($3)",
+            Expectation,
+            [103],
+            id="standard_observable",
+        ),
+        pytest.param(
+            "braket result sample z($1) @ z($4)",
+            Sample,
+            [101, 104],
+            id="tensor_product_observable",
+        ),
+        pytest.param(
+            "braket result variance x($7)",
+            Variance,
+            [107],
+            id="variance",
+        ),
+        pytest.param(
+            "braket result probability $2, $5",
+            Probability,
+            [102, 105],
+            id="multi_target_probability",
+        ),
+        pytest.param(
+            "braket result density_matrix $0, $1",
+            DensityMatrix,
+            [100, 101],
+            id="multi_target_density_matrix",
+        ),
+        pytest.param(
+            "braket result expectation hermitian([[0+0im, 1+0im], [1+0im, 0+0im]]) $6",
+            Expectation,
+            [106],
+            id="hermitian_observable",
+        ),
+    ],
+)
+def test_hardware_qubit_routes_through_qubit_table(pragma_body, result_type, expected_targets):
+    """Every pragma shape must reach QubitTable.get_by_identifier for ``$N`` targets.
+
+    The offset subclass shifts each resolved index by ``+100`` so the raw-label
+    text-hack path in ``visitGateOperand`` (which never consults the table) is
+    directly observable as a test failure.
+    """
+    result = parse_braket_pragma(pragma_body, _OffsetQubitTable())
+    assert isinstance(result, result_type)
+    assert result.targets == expected_targets
+
+
+def test_default_qubit_table_unchanged_behavior():
+    """The default QubitTable resolves ``$N`` to ``(N,)``, so targets are ints."""
+    result = parse_braket_pragma("braket result expectation z($9)", QubitTable())
+    assert result.targets == [9]


### PR DESCRIPTION
visitGateOperand's HardwareQubit ($N) branch short-circuited by parsing the label text directly, returning (N,) without ever consulting the qubit_table. This was asymmetric with:

  * visitMultiTargetIdentifiers (probability, density_matrix), which always delegates to qubit_table.get_by_identifier.
  * visitIndexedIdentifier (q[i]), which also delegates.
  * AbstractProgramContext.get_qubits for gate-op $N, which delegates.

The gap meant standard-observable and tensor-product-observable pragmas (expectation z($N), sample z($1) @ z($2), variance x($N)) could not be intercepted by QubitTable subclasses. Consumers that need to translate device labels — for example a topology-aware physical-qubit map — could translate all other pragma shapes but not these two.

Route the HardwareQubit branch through qubit_table.get_by_identifier by constructing an Identifier from the token text. Default QubitTable behavior is unchanged: base get_by_identifier resolves $N to (N,).

Adds a parametrized regression test that uses an offset QubitTable subclass to prove every pragma shape (standard observable, tensor product, variance, multi-target probability, multi-target density matrix, hermitian observable) is now subclass-observable. Plus a legacy-behavior test using the default table to pin the unchanged default resolution.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
